### PR TITLE
[Feature][Task-88] 공통 모달 컴포넌트 구현

### DIFF
--- a/packages/user/package.json
+++ b/packages/user/package.json
@@ -16,8 +16,10 @@
 		"react-router-dom": "^6.25.1"
 	},
 	"dependencies": {
+		"@radix-ui/react-dialog": "^1.1.1",
 		"@radix-ui/react-slot": "^1.1.0",
 		"@radix-ui/react-toast": "^1.2.1",
+		"@radix-ui/react-visually-hidden": "^1.1.0",
 		"@tanstack/react-query": "^5.51.11",
 		"@vitejs/plugin-react": "^4.3.1",
 		"class-variance-authority": "^0.7.0",

--- a/packages/user/src/assets/icons/close.svg
+++ b/packages/user/src/assets/icons/close.svg
@@ -1,0 +1,6 @@
+<svg width="39" height="39" viewBox="0 0 39 39" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 111">
+<path id="Line 3" d="M2 37L37 2" stroke="#A9A9A9" stroke-width="3" stroke-linecap="round"/>
+<path id="Line 4" d="M37 37L2 2" stroke="#A9A9A9" stroke-width="3" stroke-linecap="round"/>
+</g>
+</svg>

--- a/packages/user/src/components/common/Button.tsx
+++ b/packages/user/src/components/common/Button.tsx
@@ -24,8 +24,7 @@ const buttonVariants = cva(clsx(buttonStyles, defaultStyles), {
 	},
 });
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
-	VariantProps<typeof buttonVariants>;
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>;
 
 /** 랜딩 페이지 이동(size: lg), 팝업 버튼(size: default) */
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/packages/user/src/components/common/Modal.tsx
+++ b/packages/user/src/components/common/Modal.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import { Dialog, DialogContent, DialogProps, DialogTrigger } from 'src/components/ui/dialog';
+
+interface ModalProps extends DialogProps {
+	openTrigger: ReactElement;
+}
+export default function Modal({ openTrigger, children, ...props }: PropsWithChildren<ModalProps>) {
+	return (
+		<Dialog>
+			<DialogTrigger asChild>{openTrigger}</DialogTrigger>
+			<DialogContent {...props}>{children}</DialogContent>
+		</Dialog>
+	);
+}

--- a/packages/user/src/components/ui/dialog.tsx
+++ b/packages/user/src/components/ui/dialog.tsx
@@ -33,7 +33,7 @@ const dialogVariants = cva(
 	{
 		variants: {
 			variants: {
-				default: 'bg-background/80',
+				default: 'bg-background/80 backdrop-blur-lg',
 				pet: 'bg-gradient-pet',
 				place: 'bg-gradient-place',
 				travel: 'bg-gradient-travel',

--- a/packages/user/src/components/ui/dialog.tsx
+++ b/packages/user/src/components/ui/dialog.tsx
@@ -1,0 +1,118 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
+import { cva, VariantProps } from 'class-variance-authority';
+import React from 'react';
+import Close from 'src/assets/icons/close.svg?react';
+import cn from 'src/utils/cn';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = DialogPrimitive.Portal;
+
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Overlay>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Overlay
+		ref={ref}
+		className={cn(
+			'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80',
+			className,
+		)}
+		{...props}
+	/>
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const dialogVariants = cva(
+	`rounded-6 border-2 border-khaki-500 backdrop-blur-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 aspect-[16/9] data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-50 grid w-[960px] h-[540px] translate-x-[-50%] translate-y-[-50%] p-[30px] shadow-lg duration-200`,
+	{
+		variants: {
+			variants: {
+				default: 'bg-background opacity-80',
+				pet: 'bg-gradient-pet opacity-80',
+				place: 'bg-gradient-place  opacity-70',
+				travel: 'bg-gradient-travel  opacity-70',
+				leisure: 'bg-gradient-leisure  opacity-70',
+			},
+		},
+		defaultVariants: {
+			variants: 'default',
+		},
+	},
+);
+
+export type DialogProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> &
+	VariantProps<typeof dialogVariants>;
+
+const DialogContent = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Content>,
+	DialogProps
+>(({ className, variants, children, ...props }, ref) => {
+	// const default = 'bg-popup-line opacity-70 '
+
+	return (
+		<DialogPortal>
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				className={cn(dialogVariants({ variants, className }))}
+				ref={ref}
+				{...props}
+			>
+				<VisuallyHidden.Root>
+					<DialogTitle />
+					<DialogDescription />
+				</VisuallyHidden.Root>
+				{children}
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-foreground data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-[15px] top-[15px] h-[30px] w-[30px] rounded-[2px] p-[4px] opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+					<Close className="h-full w-full" />
+				</DialogPrimitive.Close>
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+});
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+	<div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogTitle = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Title>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Title
+		ref={ref}
+		className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+		{...props}
+	/>
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+	React.ElementRef<typeof DialogPrimitive.Description>,
+	React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+	<DialogPrimitive.Description
+		ref={ref}
+		className={cn('text-muted-foreground text-sm', className)}
+		{...props}
+	/>
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTrigger,
+};

--- a/packages/user/src/components/ui/dialog.tsx
+++ b/packages/user/src/components/ui/dialog.tsx
@@ -33,11 +33,11 @@ const dialogVariants = cva(
 	{
 		variants: {
 			variants: {
-				default: 'bg-background opacity-80',
-				pet: 'bg-gradient-pet opacity-80',
-				place: 'bg-gradient-place  opacity-70',
-				travel: 'bg-gradient-travel  opacity-70',
-				leisure: 'bg-gradient-leisure  opacity-70',
+				default: 'bg-background/80',
+				pet: 'bg-gradient-pet',
+				place: 'bg-gradient-place',
+				travel: 'bg-gradient-travel',
+				leisure: 'bg-gradient-leisure',
 			},
 		},
 		defaultVariants: {

--- a/packages/user/src/components/ui/dialog.tsx
+++ b/packages/user/src/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogContent = React.forwardRef<
 					<DialogDescription />
 				</VisuallyHidden.Root>
 				{children}
-				<DialogPrimitive.Close className="ring-offset-background focus:ring-foreground data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-[15px] top-[15px] h-[30px] w-[30px] rounded-[2px] p-[4px] opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+				<DialogPrimitive.Close className="ring-offset-background focus:ring-foreground data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute right-[30px] top-[30px] h-[30px] w-[30px] rounded-[2px] p-[4px] opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
 					<Close className="h-full w-full" />
 				</DialogPrimitive.Close>
 			</DialogPrimitive.Content>

--- a/packages/user/src/styles/index.css
+++ b/packages/user/src/styles/index.css
@@ -71,17 +71,16 @@ p > strong {
 	@apply text-primary;
 }
 
-
 /** scroll snap */
 
 main {
-	@apply overflow-auto snap-y snap-proximity;
+	@apply snap-y snap-proximity overflow-auto;
 }
 
-section,footer {
+section,
+footer {
 	@apply snap-start;
 }
-
 
 /* shadcn ui */
 

--- a/packages/user/src/styles/theme.ts
+++ b/packages/user/src/styles/theme.ts
@@ -139,10 +139,16 @@ const fontWeight = {
 const backgroundImage = {
 	'gradient-lineBanner': 'linear-gradient(to right, #2589FF, #232AA3)',
 	'gradient-cards1': 'linear-gradient(to right, #FD7A4D, #000000)',
+	'gradient-cards3': 'linear-gradient(to right, #37392A, #000000)',
 	'gradient-cards2': 'linear-gradient(to right, #939393, #000000)',
+	'gradient-cards4': 'linear-gradient(to right, #BFC3A1, #000000)',
 	'gradient-gauge1': 'linear-gradient(to right, #5D85D2, #8093BB, #60E9FB)',
 	'gradient-gauge2': 'linear-gradient(to right, #E0A64F, #FFF59E, #FFE500)',
 	'gradient-gauge3': 'linear-gradient(to right, #D25C7F, #E37D9B, #FF3C76)',
+	'gradient-leisure': 'linear-gradient(to bottom, #535353, #d4d4d4)',
+	'gradient-travel': 'linear-gradient(to bottom, #A9A9A9, #66331c)',
+	'gradient-pet': 'linear-gradient(to bottom, #33332b, #999980)',
+	'gradient-place': 'linear-gradient(to bottom, #0A0B08, #484A3D)',
 };
 
 export { backgroundImage, colors, fontFamily, fontSize, fontWeight, spacing };

--- a/packages/user/src/styles/theme.ts
+++ b/packages/user/src/styles/theme.ts
@@ -145,10 +145,10 @@ const backgroundImage = {
 	'gradient-gauge1': 'linear-gradient(to right, #5D85D2, #8093BB, #60E9FB)',
 	'gradient-gauge2': 'linear-gradient(to right, #E0A64F, #FFF59E, #FFE500)',
 	'gradient-gauge3': 'linear-gradient(to right, #D25C7F, #E37D9B, #FF3C76)',
-	'gradient-leisure': 'linear-gradient(to bottom, #535353, #d4d4d4)',
-	'gradient-travel': 'linear-gradient(to bottom, #A9A9A9, #66331c)',
-	'gradient-pet': 'linear-gradient(to bottom, #33332b, #999980)',
-	'gradient-place': 'linear-gradient(to bottom, #0A0B08, #484A3D)',
+	'gradient-leisure': 'linear-gradient(to bottom, #53535382, #d4d4d482)',
+	'gradient-travel': 'linear-gradient(to bottom, #A9A9A982, #66331c82)',
+	'gradient-pet': 'linear-gradient(to bottom, #33332bcc, #999980cc)',
+	'gradient-place': 'linear-gradient(to bottom, #0A0B0882, #484A3D82)',
 };
 
 export { backgroundImage, colors, fontFamily, fontSize, fontWeight, spacing };

--- a/packages/user/tailwind.config.ts
+++ b/packages/user/tailwind.config.ts
@@ -27,7 +27,7 @@ const config: Config = {
 		extend: {
 			spacing,
 			boxShadow: {
-				lg: '0px 0px 20px 0px #ffffffD0', // popup
+				lg: '0px 0px 20px 0px #ffffffD0', // modal
 			},
 			container: {
 				center: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,7 +1066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-visually-hidden@npm:1.1.0":
+"@radix-ui/react-visually-hidden@npm:1.1.0, @radix-ui/react-visually-hidden@npm:^1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-visually-hidden@npm:1.1.0"
   dependencies:
@@ -6420,8 +6420,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "user@workspace:packages/user"
   dependencies:
+    "@radix-ui/react-dialog": "npm:^1.1.1"
     "@radix-ui/react-slot": "npm:^1.1.0"
     "@radix-ui/react-toast": "npm:^1.2.1"
+    "@radix-ui/react-visually-hidden": "npm:^1.1.0"
     "@tanstack/react-query": "npm:^5.51.11"
     "@vitejs/plugin-react": "npm:^4.3.1"
     autoprefixer: "npm:^10.4.19"


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
> backdrop blur 적용 안돼서 고생 좀 했읍니다.. 색상 자체에 opacity 를 넣어줘야 작동하더라고요 

- shadcn component 기반으로 커스터마이징
- variant로 기본(default), 유형 별(pet, travel, place, leisure) 모달 구분
  <br/>

## 이미지 첨부
> variant 별

1. default
<img width="1133" alt="스크린샷 2024-07-31 오후 5 18 54" src="https://github.com/user-attachments/assets/23dfccd9-8188-4f7b-b17a-f76a4201a65c">

2. pet
<img width="1159" alt="스크린샷 2024-07-31 오후 5 17 53" src="https://github.com/user-attachments/assets/8ffe3a34-696e-405a-a5ca-bdbbc725fcaa">

3. travel
<img width="1206" alt="스크린샷 2024-07-31 오후 5 19 14" src="https://github.com/user-attachments/assets/e2933132-9617-4bcd-a83e-583c22873568">

4. place
<img width="1249" alt="스크린샷 2024-07-31 오후 5 17 08" src="https://github.com/user-attachments/assets/7bcecee9-d484-4a41-aaa7-7c09f1a3170c">

5. leisure
<img width="1135" alt="스크린샷 2024-07-31 오후 5 19 37" src="https://github.com/user-attachments/assets/e7daf0a4-5272-4374-b70a-2b939ef0ba75">

<br/>
