### PR TITLE
[Feature][Task-135] 로그인 모달 구현 및 API 연동 & 로그인이 선행되어야 하는 기능을 위해 공통 Protected 로직 구현 (HOC) & 그 외 다수의 관련된 에러 해결

### DIFF
--- a/packages/user/src/components/event/chatting/Chat.tsx
+++ b/packages/user/src/components/event/chatting/Chat.tsx
@@ -15,7 +15,7 @@ export default function Chat({ type, team, sender, content }: ChatProps) {
 			case 'm':
 			default:
 				return (
-					<Message sender={sender} team={team} isMyMessage={me?.id === sender}>
+					<Message sender={sender} team={team} isMyMessage={me?.id === sender.toString()}>
 						{content}
 					</Message>
 				);

--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -1,22 +1,26 @@
 import { ChatList } from '@softeer/common/components';
+import { memo } from 'react';
+import ChatInput from 'src/components/event/chatting/inputArea/input/index.tsx';
 import { UseChatSocketReturnType } from 'src/hooks/socket/useChatSocket.ts';
 import Chat from './Chat.tsx';
 import ChatInputArea from './inputArea/index.tsx';
 
 /** 실시간 기대평 섹션 */
 
-export default function RealTimeChatting({ onSendMessage, messages }: UseChatSocketReturnType) {
-	return (
-		<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
-			<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>
-			<ChatInputArea onSend={onSendMessage} />
-			<div className="h-[1000px] w-full overflow-y-auto rounded-[10px] bg-neutral-800 py-10">
-				<ChatList>
-					{messages.map((message) => (
-						<Chat key={message.id} {...message} />
-					))}
-				</ChatList>
-			</div>
-		</section>
-	);
-}
+const RealTimeChatting = memo(({ onSendMessage, messages }: UseChatSocketReturnType) => (
+	<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
+		<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>
+		<ChatInputArea>
+			<ChatInput onSend={onSendMessage} />
+		</ChatInputArea>
+		<div className="h-[1000px] w-full overflow-y-auto rounded-[10px] bg-neutral-800 py-10">
+			<ChatList>
+				{messages.map((message) => (
+					<Chat key={message.id} {...message} />
+				))}
+			</ChatList>
+		</div>
+	</section>
+));
+
+export default RealTimeChatting;

--- a/packages/user/src/components/event/chatting/inputArea/index.tsx
+++ b/packages/user/src/components/event/chatting/inputArea/index.tsx
@@ -1,16 +1,13 @@
-import ChatInput from './input/index.tsx';
+import { PropsWithChildren } from 'react';
 
-interface ChatInputAreaProps {
-	onSend: (message: string) => void;
-}
-export default function ChatInputArea({ onSend }: ChatInputAreaProps) {
+export default function ChatInputArea({ children }: PropsWithChildren) {
 	return (
 		<div className="mb-[54px] flex flex-col items-center gap-3">
 			{/* Todo: 비속어 작성 횟수 불러오기 */}
 			<p className="text-detail-2 text-[#FF3C76]">
 				비속어 혹은 부적절한 기대평을 5회 이상 작성할 경우, 댓글 작성이 제한됩니다.
 			</p>
-			<ChatInput onSend={onSend} />
+			{children}
 		</div>
 	);
 }

--- a/packages/user/src/components/event/chatting/inputArea/input/index.tsx
+++ b/packages/user/src/components/event/chatting/inputArea/input/index.tsx
@@ -1,9 +1,11 @@
-import { useRef } from 'react';
+import { memo, useCallback, useRef } from 'react';
 import OutlinedButton from 'src/components/common/OutlinedButton.tsx';
 import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import { useToast } from 'src/hooks/useToast.ts';
 import Input from './Input.tsx';
+
+const ProtectedWrapper = memo(withAuth(() => <OutlinedButton>보내기</OutlinedButton>));
 
 const DISABLED_CHATTING_TOAST_DESCRIPTION = '로그인 후 채팅에 참여할 수 있습니다!';
 interface ChatInputProps {
@@ -15,7 +17,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
 
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+	const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 
 		const disabledChatting = !isAuthenticated;
@@ -29,9 +31,7 @@ export default function ChatInput({ onSend }: ChatInputProps) {
 			onSend(inputRef.current.value);
 			inputRef.current.value = '';
 		}
-	}
-
-	const ProtectedWrapper = withAuth(() => <OutlinedButton type="submit">보내기</OutlinedButton>);
+	}, [isAuthenticated]);
 
 	return (
 		<form className="flex items-center gap-4" onSubmit={handleSubmit}>

--- a/packages/user/src/components/event/chatting/inputArea/input/index.tsx
+++ b/packages/user/src/components/event/chatting/inputArea/input/index.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import OutlinedButton from 'src/components/common/OutlinedButton.tsx';
-import LoginModal from 'src/components/shared/modal/login/index.tsx';
+import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import { useToast } from 'src/hooks/useToast.ts';
 import Input from './Input.tsx';
@@ -31,14 +31,14 @@ export default function ChatInput({ onSend }: ChatInputProps) {
 		}
 	}
 
+	const ProtectedWrapper = withAuth(() => <OutlinedButton type="submit">보내기</OutlinedButton>);
+
 	return (
 		<form className="flex items-center gap-4" onSubmit={handleSubmit}>
 			<Input ref={inputRef} name="input" required />
-			{isAuthenticated ? (
-				<OutlinedButton type="submit">보내기</OutlinedButton>
-			) : (
-				<LoginModal openTrigger={<OutlinedButton>로그인하고 채팅 보내기</OutlinedButton>} />
-			)}
+			<ProtectedWrapper
+				unauthenticatedDisplay={<OutlinedButton>로그인하고 채팅 보내기</OutlinedButton>}
+			/>
 		</form>
 	);
 }

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -25,25 +25,23 @@ export interface ChargeButtonData {
 	percentage: number;
 }
 
-const ControlButton = memo(
-	({ onCharge, onFullyCharged, type, data }: ControlButtonProps) => {
-		const { rank, percentage } = data;
-		const { progress, clickCount, handleClick } = useGaugeProgress({
-			percentage,
-			onCharge,
-			onFullyCharged,
-		});
+const ControlButton = memo(({ onCharge, onFullyCharged, type, data }: ControlButtonProps) => {
+	const { rank, percentage } = data;
+	const { progress, clickCount, handleClick } = useGaugeProgress({
+		percentage,
+		onCharge,
+		onFullyCharged,
+	});
 
-		return (
-			<ControllButtonWrapper rank={rank}>
-				<Gauge percent={progress} />
-				<ChargeButtonWrapper onClick={handleClick} disabled={clickCount === MAX_CLICK} type={type}>
-					<ChargeButtonContent type={type} {...data} />
-				</ChargeButtonWrapper>
-			</ControllButtonWrapper>
-		);
-	},
-);
+	return (
+		<ControllButtonWrapper rank={rank}>
+			<Gauge percent={progress} />
+			<ChargeButtonWrapper onClick={handleClick} disabled={clickCount === MAX_CLICK} type={type}>
+				<ChargeButtonContent type={type} {...data} />
+			</ChargeButtonWrapper>
+		</ControllButtonWrapper>
+	);
+});
 
 export default ControlButton;
 

--- a/packages/user/src/components/event/racing/dashboard/card/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
 import TeamSelectModal from 'src/components/shared/modal/teamSelectModal/index.tsx';
 import ShareCountTeamCard from 'src/components/shared/ShareCountTeamCard.tsx';
+import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import UnassignedCard from './UnassignedCard.tsx';
 
@@ -10,20 +11,24 @@ export default function RacingCard() {
 	const { user } = useAuth();
 	const [type, setType] = useState<Category | undefined>(user?.type);
 
+	const ProtectedTeamSelectModal = withAuth(() => (
+		<TeamSelectModal
+			openTrigger={
+				<TriggerButtonWrapper>
+					<UnassignedCard />
+				</TriggerButtonWrapper>
+			}
+			onClose={() => setType(user?.type)} // onClose를 사용해 타입을 설정
+		/>
+	));
+
 	return (
 		<div className="bg-foreground/10 flex flex-col items-center rounded-[5px] p-4 pt-2 backdrop-blur-sm">
 			<CardTitle name={user?.name} />
 			{type ? (
 				<ShareCountTeamCard type={type} size="racing" />
 			) : (
-				<TeamSelectModal
-					openTrigger={
-						<TriggerButtonWrapper>
-							<UnassignedCard />
-						</TriggerButtonWrapper>
-					}
-					onClose={() => setType(user?.type)}
-				/>
+				<ProtectedTeamSelectModal unauthenticatedDisplay={<UnassignedCard />} />
 			)}
 		</div>
 	);

--- a/packages/user/src/components/event/racing/dashboard/card/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/index.tsx
@@ -1,26 +1,17 @@
 import { Category } from '@softeer/common/types';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
-import TeamSelectModal from 'src/components/shared/modal/teamSelectModal/index.tsx';
+import TeamSelectModal, { type TeamSelectModalProps } from 'src/components/shared/modal/teamSelectModal/index.tsx';
 import ShareCountTeamCard from 'src/components/shared/ShareCountTeamCard.tsx';
 import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import UnassignedCard from './UnassignedCard.tsx';
 
+const ProtectedTeamSelectModal = memo(withAuth<TeamSelectModalProps>(TeamSelectModal));
+
 export default function RacingCard() {
 	const { user } = useAuth();
 	const [type, setType] = useState<Category | undefined>(user?.type);
-
-	const ProtectedTeamSelectModal = withAuth(() => (
-		<TeamSelectModal
-			openTrigger={
-				<TriggerButtonWrapper>
-					<UnassignedCard />
-				</TriggerButtonWrapper>
-			}
-			onClose={() => setType(user?.type)} // onClose를 사용해 타입을 설정
-		/>
-	));
 
 	return (
 		<div className="bg-foreground/10 flex flex-col items-center rounded-[5px] p-4 pt-2 backdrop-blur-sm">
@@ -28,7 +19,15 @@ export default function RacingCard() {
 			{type ? (
 				<ShareCountTeamCard type={type} size="racing" />
 			) : (
-				<ProtectedTeamSelectModal unauthenticatedDisplay={<UnassignedCard />} />
+				<ProtectedTeamSelectModal
+					openTrigger={
+						<TriggerButtonWrapper>
+							<UnassignedCard />
+						</TriggerButtonWrapper>
+					}
+					onClose={() => setType(user?.type)}
+					unauthenticatedDisplay={<UnassignedCard />}
+				/>
 			)}
 		</div>
 	);

--- a/packages/user/src/components/layout/fcfsController/index.tsx
+++ b/packages/user/src/components/layout/fcfsController/index.tsx
@@ -9,15 +9,15 @@ const EVENT_OPEN_HOUR = 15;
 const EVENT_OPEN_MINUTE = 15;
 
 const ProtectedFCFSButton = withAuth(() => (
-  <FCFSModal
-    openTrigger={
-      <TriggerButtonWrapper>
-        <TriggerButtonLike>
-          선착순 퀴즈 <p className="text-heading-8 text-foreground font-extrabold">OPEN</p>
-        </TriggerButtonLike>
-      </TriggerButtonWrapper>
-    }
-  />
+	<FCFSModal
+		openTrigger={
+			<TriggerButtonWrapper>
+				<TriggerButtonLike>
+					선착순 퀴즈 <p className="text-heading-8 text-foreground font-extrabold">OPEN</p>
+				</TriggerButtonLike>
+			</TriggerButtonWrapper>
+		}
+	/>
 ));
 
 export default function FCFSFloatingButtonController() {
@@ -37,7 +37,7 @@ export default function FCFSFloatingButtonController() {
 					</TriggerButtonLike>
 				}
 			/>
-  </Suspense>
+		</Suspense>
 	);
 }
 

--- a/packages/user/src/components/layout/fcfsController/index.tsx
+++ b/packages/user/src/components/layout/fcfsController/index.tsx
@@ -1,7 +1,6 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
-import LoginModal from 'src/components/shared/modal/login/index.tsx';
-import useAuth from 'src/hooks/useAuth.tsx';
+import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import TriggerButtonLike from './TriggerButtonLike.tsx';
 
 const FCFSModal = lazy(() => import('src/components/shared/modal/fcfs/index.tsx'));
@@ -9,8 +8,19 @@ const FCFSModal = lazy(() => import('src/components/shared/modal/fcfs/index.tsx'
 const EVENT_OPEN_HOUR = 15;
 const EVENT_OPEN_MINUTE = 15;
 
+const ProtectedFCFSButton = withAuth(() => (
+  <FCFSModal
+    openTrigger={
+      <TriggerButtonWrapper>
+        <TriggerButtonLike>
+          선착순 퀴즈 <p className="text-heading-8 text-foreground font-extrabold">OPEN</p>
+        </TriggerButtonLike>
+      </TriggerButtonWrapper>
+    }
+  />
+));
+
 export default function FCFSFloatingButtonController() {
-	const { isAuthenticated } = useAuth();
 	const shouldLoadComponent = useEventActivation(EVENT_OPEN_HOUR, EVENT_OPEN_MINUTE);
 
 	// 설정한 시각 이전에는 버튼 노출하지 않음
@@ -18,34 +28,16 @@ export default function FCFSFloatingButtonController() {
 		return null;
 	}
 
-	// 로그인하지 않은 유저에게는 로그인 모달 트리거 버튼 노출
-	if (!isAuthenticated) {
-		return (
-			<LoginModal
-				openTrigger={
-					<TriggerButtonWrapper>
-						<TriggerButtonLike>
-							<p className="text-heading-8 text-foreground font-bold">로그인</p>하고 퀴즈 풀기
-						</TriggerButtonLike>
-					</TriggerButtonWrapper>
-				}
-			/>
-		);
-	}
-
-	// 로그인한 유저에게는 선착순 퀴즈 모달 트리거 버튼 노출
 	return (
 		<Suspense>
-			<FCFSModal
-				openTrigger={
-					<TriggerButtonWrapper>
-						<TriggerButtonLike>
-							선착순 퀴즈 <p className="text-heading-8 text-foreground font-extrabold">OPEN</p>
-						</TriggerButtonLike>
-					</TriggerButtonWrapper>
+			<ProtectedFCFSButton
+				unauthenticatedDisplay={
+					<TriggerButtonLike>
+						<p className="text-heading-8 text-foreground font-bold">로그인</p>하고 퀴즈 풀기
+					</TriggerButtonLike>
 				}
 			/>
-		</Suspense>
+  </Suspense>
 	);
 }
 

--- a/packages/user/src/components/layout/header/user/index.tsx
+++ b/packages/user/src/components/layout/header/user/index.tsx
@@ -1,4 +1,6 @@
 import UserIcon from 'src/assets/icons/user.svg?react';
+import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
+import LoginModal from 'src/components/shared/modal/login/index.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import SpeechBubble from './SpeechBubble.tsx';
 
@@ -13,9 +15,7 @@ export default function User() {
 			) : (
 				<>
 					<SpeechBubble />
-					<button type="button" aria-label="user-icon" className="p-[10px]">
-						<UserIcon />
-					</button>
+					<LoginModal openTrigger={<TriggerButtonWrapper><UserIcon /></TriggerButtonWrapper>} />
 				</>
 			)}
 		</div>

--- a/packages/user/src/components/layout/header/user/index.tsx
+++ b/packages/user/src/components/layout/header/user/index.tsx
@@ -4,18 +4,16 @@ import SpeechBubble from './SpeechBubble.tsx';
 
 const UserGreeting = withAuth(() => <p className="text-detail-1">김보민님 반갑습니다</p>);
 
+// TODO: 로그아웃
 export default function User() {
-	// TODO: 로그아웃
 	return (
-		<div className="flex items-center gap-2">
-			<UserGreeting
-				unauthenticatedDisplay={
-					<>
-						<SpeechBubble />
-						<UserIcon />
-					</>
-				}
-			/>
-		</div>
+		<UserGreeting
+			unauthenticatedDisplay={
+				<div className="flex items-center gap-2">
+					<SpeechBubble />
+					<UserIcon />
+				</div>
+			}
+		/>
 	);
 }

--- a/packages/user/src/components/layout/header/user/index.tsx
+++ b/packages/user/src/components/layout/header/user/index.tsx
@@ -1,29 +1,21 @@
 import UserIcon from 'src/assets/icons/user.svg?react';
-import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
-import LoginModal from 'src/components/shared/modal/login/index.tsx';
-import useAuth from 'src/hooks/useAuth.tsx';
+import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import SpeechBubble from './SpeechBubble.tsx';
 
-export default function User() {
-	const { user } = useAuth();
+const UserGreeting = withAuth(() => <p className="text-detail-1">김보민님 반갑습니다</p>);
 
-	// TODO: 로그인, 로그아웃
+export default function User() {
+	// TODO: 로그아웃
 	return (
 		<div className="flex items-center gap-2">
-			{user ? (
-				<p className="text-detail-1">김보민님 반갑습니다</p>
-			) : (
-				<>
-					<SpeechBubble />
-					<LoginModal
-						openTrigger={
-							<TriggerButtonWrapper>
-								<UserIcon />
-							</TriggerButtonWrapper>
-						}
-					/>
-				</>
-			)}
+			<UserGreeting
+				unauthenticatedDisplay={
+					<>
+						<SpeechBubble />
+						<UserIcon />
+					</>
+				}
+			/>
 		</div>
 	);
 }

--- a/packages/user/src/components/layout/header/user/index.tsx
+++ b/packages/user/src/components/layout/header/user/index.tsx
@@ -15,7 +15,13 @@ export default function User() {
 			) : (
 				<>
 					<SpeechBubble />
-					<LoginModal openTrigger={<TriggerButtonWrapper><UserIcon /></TriggerButtonWrapper>} />
+					<LoginModal
+						openTrigger={
+							<TriggerButtonWrapper>
+								<UserIcon />
+							</TriggerButtonWrapper>
+						}
+					/>
 				</>
 			)}
 		</div>

--- a/packages/user/src/components/shared/modal/InfoStep.tsx
+++ b/packages/user/src/components/shared/modal/InfoStep.tsx
@@ -2,8 +2,8 @@ import { PropsWithChildren } from 'react';
 
 export default function InfoStep({ children }: PropsWithChildren) {
 	return (
-		<div className="flex h-full w-full flex-col items-center justify-center gap-10 p-[20px]">
-			<img src="/images/fcfs/modal.png" alt="modal" className="h-full object-contain" />
+		<div className="flex h-full flex-col items-center justify-center gap-10 p-[20px]">
+			<img src="/images/fcfs/modal.png" alt="modal" className="max-w-[500px] object-contain" />
 			<div className="text-heading-12 flex flex-col items-center gap-4 font-medium">{children}</div>
 		</div>
 	);

--- a/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
@@ -4,7 +4,7 @@ import OptionButton from 'src/components/common/OptionButton.tsx';
 import useGetFCFSQuiz from 'src/hooks/query/useGetFCFSQuiz.ts';
 import useSubmitFCFSQuiz, { SubmitFCFSQuizResponse } from 'src/hooks/query/useSubmitFCFSQuiz.ts';
 
-type ResultStepType = ReturnType<typeof getResultStepFromStatus>;
+export type ResultStepType = ReturnType<typeof getResultStepFromStatus>;
 interface QuizStepProps {
 	onStepChange: (step: ResultStepType | 'pending') => void;
 }

--- a/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
@@ -1,15 +1,30 @@
+import { useEffect } from 'react';
 import Chip from 'src/components/common/Chip.tsx';
 import OptionButton from 'src/components/common/OptionButton.tsx';
 import useGetFCFSQuiz from 'src/hooks/query/useGetFCFSQuiz.ts';
+import useSubmitFCFSQuiz, { SubmitFCFSQuizResponse } from 'src/hooks/query/useSubmitFCFSQuiz.ts';
 
+type ResultStepType = ReturnType<typeof getResultStepFromStatus>;
 interface QuizStepProps {
-	onSelect: (answer: number) => void;
+	onStepChange: (step: ResultStepType | 'pending') => void;
 }
 
-export default function QuizStep({ onSelect }: QuizStepProps) {
+export default function QuizStep({ onStepChange }: QuizStepProps) {
 	const {
 		quiz: { question, choices },
 	} = useGetFCFSQuiz();
+
+	const { isPending, mutate: submitAnswer } = useSubmitFCFSQuiz();
+
+	useEffect(() => {
+		if (isPending) onStepChange('pending');
+	}, [isPending]);
+
+	const handleSubmit = (answer: number) =>
+		submitAnswer(
+			{ answer },
+			{ onSuccess: (response) => onStepChange(getResultStepFromStatus(response)) },
+		);
 
 	return (
 		<div className="flex h-full w-full max-w-[400px] flex-col justify-between gap-9 sm:max-w-[500px] md:max-w-[650px] lg:max-w-[800px]">
@@ -19,11 +34,24 @@ export default function QuizStep({ onSelect }: QuizStepProps) {
 			</div>
 			<div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2">
 				{choices.map(({ num, text }) => (
-					<OptionButton key={num} onClick={() => onSelect(num)}>
+					<OptionButton key={num} onClick={() => handleSubmit(num)}>
 						{text}
 					</OptionButton>
 				))}
 			</div>
 		</div>
 	);
+}
+
+function getResultStepFromStatus({ status }: SubmitFCFSQuizResponse) {
+	switch (status) {
+		case 'END':
+			return 'end';
+		case 'PARTICIPATED':
+			return 'already-done';
+		case 'WRONG':
+			return 'wrong-answer';
+		default:
+			return 'correct-answer';
+	}
 }

--- a/packages/user/src/components/shared/modal/fcfs/ResultStep.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/ResultStep.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import type { ResultStepType } from 'src/components/shared/modal/fcfs/index.tsx';
+import type { ResultStepType } from './QuizStep.tsx';
 
 interface ResultStepProps {
 	step: ResultStepType;
@@ -8,9 +8,10 @@ interface ResultStepProps {
 export default function ResultStep({ step }: ResultStepProps) {
 	const imageUrl = IMAGE_URLS[step];
 	const { title, subTitle, details } = DESCRIPTIONS[step];
+
 	return (
 		<div className="flex h-full w-full flex-col items-center justify-center p-[20px]">
-			<img src={imageUrl} alt="modal" className="h-[230px] object-contain" />
+			<img src={imageUrl} alt={`${step} 캐스퍼 캐릭터`} className="h-[230px] object-contain" />
 			<p className="text-heading-7 mb-9 font-bold">{title}</p>
 			<p className="text-body-1 mb-4 whitespace-pre-line text-center font-medium">{subTitle}</p>
 			<caption className="text-body-4 text-neutral-100">{details}</caption>

--- a/packages/user/src/components/shared/modal/fcfs/index.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/index.tsx
@@ -1,15 +1,12 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { Suspense, useEffect } from 'react';
+import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import Modal, { ModalProps } from 'src/components/common/Modal.tsx';
 import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
-import useSubmitFCFSQuiz, { SubmitFCFSQuizResponse } from 'src/hooks/query/useSubmitFCFSQuiz.ts';
 import useFunnel from 'src/hooks/useFunnel.ts';
 import ErrorStep from './ErrorStep.tsx';
 import QuizStep from './QuizStep.tsx';
 import ResultStep from './ResultStep.tsx';
-
-export type ResultStepType = ReturnType<typeof getResultStepFromStatus>;
 
 export default function FCFSModal(props: ModalProps) {
 	const [Funnel, setStep] = useFunnel(
@@ -26,18 +23,6 @@ export default function FCFSModal(props: ModalProps) {
 		},
 	);
 
-	const { isPending, mutate: submitAnswer } = useSubmitFCFSQuiz();
-
-	useEffect(() => {
-		if (isPending) setStep('pending');
-	}, [isPending]);
-
-	const handleSubmit = (answer: number) =>
-		submitAnswer(
-			{ answer },
-			{ onSuccess: (response) => setStep(getResultStepFromStatus(response)) },
-		);
-
 	return (
 		<Modal {...props}>
 			<div className="flex h-full w-full items-center justify-center p-[100px]">
@@ -47,7 +32,7 @@ export default function FCFSModal(props: ModalProps) {
 							{({ reset }) => (
 								<ErrorBoundary onReset={reset} FallbackComponent={ErrorStep}>
 									<Suspense fallback={<PendingStep>선착순 퀴즈 불러오는 중...</PendingStep>}>
-										<QuizStep onSelect={handleSubmit} />
+										<QuizStep onStepChange={setStep} />
 									</Suspense>
 								</ErrorBoundary>
 							)}
@@ -74,17 +59,4 @@ export default function FCFSModal(props: ModalProps) {
 			</div>
 		</Modal>
 	);
-}
-
-function getResultStepFromStatus({ status }: SubmitFCFSQuizResponse) {
-	switch (status) {
-		case 'END':
-			return 'end';
-		case 'PARTICIPATED':
-			return 'already-done';
-		case 'WRONG':
-			return 'wrong-answer';
-		default:
-			return 'correct-answer';
-	}
 }

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -4,6 +4,8 @@ import Button from 'src/components/common/Button.tsx';
 import useSubmitLogin, { SubmitLoginRequest } from 'src/hooks/query/useSubmitLogin.ts';
 import inputStyles from 'src/styles/input.ts';
 
+const SUBMIT_BUTTON_ID = 'submit-only-for-login';
+
 interface LoginStepProps {
 	onMoveSuccessStep: () => void;
 }
@@ -16,6 +18,7 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 
 	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
+		e.stopPropagation();
 		const submitData = { userId: inputRefs.current[0].value, password: inputRefs.current[1].value };
 		if (hasRequiredLoginFields(submitData)) {
 			login(submitData, {
@@ -26,6 +29,7 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 
 	return (
 		<form
+			id={SUBMIT_BUTTON_ID}
 			onSubmit={handleSubmit}
 			className="flex h-full w-full flex-col items-center justify-center gap-5"
 		>
@@ -54,7 +58,7 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 					className={loginInputStyles}
 				/>
 			</div>
-			<Button type="submit" className="mt-12">
+			<Button type="submit" className="mt-12" form={SUBMIT_BUTTON_ID}>
 				회원가입
 			</Button>
 		</form>

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -7,11 +7,11 @@ import inputStyles from 'src/styles/input.ts';
 const SUBMIT_BUTTON_ID = 'submit-only-for-login';
 
 interface LoginStepProps {
-	onMoveSuccessStep: () => void;
+	onSuccess: () => void;
 }
 
 // TODO: KAKAO OAuth
-export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
+export default function LoginStep({ onSuccess }: LoginStepProps) {
 	const { mutate: login } = useSubmitLogin();
 
 	const inputRefs = useRef<HTMLInputElement[]>([]);
@@ -21,9 +21,7 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 		e.stopPropagation();
 		const submitData = { userId: inputRefs.current[0].value, password: inputRefs.current[1].value };
 		if (hasRequiredLoginFields(submitData)) {
-			login(submitData, {
-				onSuccess: onMoveSuccessStep,
-			});
+			login(submitData, { onSuccess });
 		}
 	};
 

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -1,0 +1,69 @@
+/* eslint-disable no-return-assign */
+import { FormEvent, useRef } from 'react';
+import Button from 'src/components/common/Button.tsx';
+import useSubmitLogin, { SubmitLoginRequest } from 'src/hooks/query/useSubmitLogin.ts';
+import inputStyles from 'src/styles/input.ts';
+
+interface LoginStepProps {
+	onMoveSuccessStep: () => void;
+}
+
+// TODO: KAKAO OAuth
+export default function LoginStep({ onMoveSuccessStep }:LoginStepProps) {
+	const { mutate: login } = useSubmitLogin();
+
+	const inputRefs = useRef<HTMLInputElement[]>([]);
+
+	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const submitData = { userId: inputRefs.current[0].value, password: inputRefs.current[1].value };
+		if (hasRequiredLoginFields(submitData)) {
+			login(submitData, {
+				onSuccess: onMoveSuccessStep,
+			});
+		}
+	};
+
+	return (
+		<form
+			onSubmit={handleSubmit}
+			className="flex h-full w-full flex-col items-center justify-center gap-5"
+		>
+			<p className="text-heading-9 text-center font-bold">
+				이벤트 참여를 위해 <strong>로그인</strong>을 진행해주세요
+			</p>
+			<div>
+				<input
+					type="text"
+					defaultValue="user"
+					name="userId"
+					placeholder="ID"
+					autoComplete="id"
+					ref={(el) => (inputRefs.current[0] = el!)}
+					className={loginInputStyles}
+				/>
+			</div>
+			<div>
+				<input
+					type="password"
+					defaultValue="1234"
+					name="password"
+					autoComplete="current-password"
+					placeholder="PASSWORD"
+					ref={(el) => (inputRefs.current[1] = el!)}
+					className={loginInputStyles}
+				/>
+			</div>
+			<Button type="submit" className="mt-12">
+				회원가입
+			</Button>
+		</form>
+	);
+}
+
+/** Helper Function */
+function hasRequiredLoginFields(inputs: Partial<SubmitLoginRequest>): inputs is SubmitLoginRequest {
+	return typeof inputs.userId === 'string' && typeof inputs.password === 'string';
+}
+
+const loginInputStyles = `${inputStyles} border border-foreground focus-visible:ring-primary rounded-2.5 h-[54px] w-[450px] bg-neutral-800 p-3 placeholder:text-neutral-300`;

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -9,7 +9,7 @@ interface LoginStepProps {
 }
 
 // TODO: KAKAO OAuth
-export default function LoginStep({ onMoveSuccessStep }:LoginStepProps) {
+export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 	const { mutate: login } = useSubmitLogin();
 
 	const inputRefs = useRef<HTMLInputElement[]>([]);

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -31,12 +31,12 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 		<form
 			id={SUBMIT_BUTTON_ID}
 			onSubmit={handleSubmit}
-			className="flex h-full w-full flex-col items-center justify-center gap-5"
+			className="flex h-full w-full flex-col items-center justify-center gap-12"
 		>
 			<p className="text-heading-9 text-center font-bold">
-				이벤트 참여를 위해 <strong>로그인</strong>을 진행해주세요
+				이벤트 참여를 위해<br /><strong>로그인</strong>을 진행해주세요
 			</p>
-			<div>
+			<div className="flex flex-col items-center justify-center gap-5">
 				<input
 					type="text"
 					defaultValue="user"
@@ -46,8 +46,6 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 					ref={(el) => (inputRefs.current[0] = el!)}
 					className={loginInputStyles}
 				/>
-			</div>
-			<div>
 				<input
 					type="password"
 					defaultValue="1234"
@@ -58,7 +56,7 @@ export default function LoginStep({ onMoveSuccessStep }: LoginStepProps) {
 					className={loginInputStyles}
 				/>
 			</div>
-			<Button type="submit" className="mt-12" form={SUBMIT_BUTTON_ID}>
+			<Button type="submit" form={SUBMIT_BUTTON_ID}>
 				회원가입
 			</Button>
 		</form>

--- a/packages/user/src/components/shared/modal/login/SuccessStep.tsx
+++ b/packages/user/src/components/shared/modal/login/SuccessStep.tsx
@@ -1,0 +1,14 @@
+import useAuth from 'src/hooks/useAuth.tsx';
+
+export default function SuccessStep() {
+  const { user } = useAuth();
+  const displayName = user?.name ?? '사용자';
+
+  return (
+    <div className="flex flex-col items-center justify-center p-[20px] h-full">
+			<img src="/images/fcfs/result/correct.png" alt="로그인 성공 캐스퍼 캐릭터" className="h-[300px] object-contain" />
+			<p className="text-body-1 font-medium text-primary">로그인 완료</p>
+			<p className="text-heading-7 font-bold">{displayName}님 환영합니다!</p>
+    </div>
+  );
+}

--- a/packages/user/src/components/shared/modal/login/index.tsx
+++ b/packages/user/src/components/shared/modal/login/index.tsx
@@ -1,7 +1,22 @@
 import Modal, { ModalProps } from 'src/components/common/Modal.tsx';
+import useFunnel from 'src/hooks/useFunnel.ts';
+import LoginStep from './LoginStep.tsx';
 
 interface LoginModalProps extends Omit<ModalProps, 'children'> {}
 
-export default function LoginModal({ openTrigger }: LoginModalProps) {
-	return <Modal openTrigger={openTrigger}>로그인 모달</Modal>;
+export default function LoginModal({ openTrigger, ...props }: LoginModalProps) {
+	const [Funnel, setStep] = useFunnel(['login', 'success', 'error'] as NonEmptyArray<string>, {
+		initialStep: 'login',
+	});
+
+	return (
+		<Modal openTrigger={openTrigger} {...props}>
+			<Funnel>
+				<Funnel.Step name="login">
+					<LoginStep onMoveSuccessStep={() => setStep('success')} />
+				</Funnel.Step>
+				<Funnel.Step name="success">로그인 성공</Funnel.Step>
+			</Funnel>
+		</Modal>
+	);
 }

--- a/packages/user/src/components/shared/modal/login/index.tsx
+++ b/packages/user/src/components/shared/modal/login/index.tsx
@@ -13,7 +13,7 @@ export default function LoginModal({ openTrigger, ...props }: LoginModalProps) {
 		<Modal openTrigger={openTrigger} {...props}>
 			<Funnel>
 				<Funnel.Step name="login">
-					<LoginStep onMoveSuccessStep={() => setStep('success')} />
+					<LoginStep onSuccess={() => setStep('success')} />
 				</Funnel.Step>
 				<Funnel.Step name="success">로그인 성공</Funnel.Step>
 			</Funnel>

--- a/packages/user/src/components/shared/modal/login/index.tsx
+++ b/packages/user/src/components/shared/modal/login/index.tsx
@@ -1,6 +1,7 @@
 import Modal, { ModalProps } from 'src/components/common/Modal.tsx';
 import useFunnel from 'src/hooks/useFunnel.ts';
 import LoginStep from './LoginStep.tsx';
+import SuccessStep from './SuccessStep.tsx';
 
 interface LoginModalProps extends Omit<ModalProps, 'children'> {}
 
@@ -15,7 +16,7 @@ export default function LoginModal({ openTrigger, ...props }: LoginModalProps) {
 				<Funnel.Step name="login">
 					<LoginStep onSuccess={() => setStep('success')} />
 				</Funnel.Step>
-				<Funnel.Step name="success">로그인 성공</Funnel.Step>
+				<Funnel.Step name="success"><SuccessStep /></Funnel.Step>
 			</Funnel>
 		</Modal>
 	);

--- a/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from 'react';
 import Modal, { ModalProps } from 'src/components/common/Modal.tsx';
-import LoginModal from 'src/components/shared/modal/login/index.tsx';
 import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import TeamSelectModalContent from './ModalContent.tsx';
@@ -9,8 +8,6 @@ interface TeamSelectModalProps extends Omit<ModalProps, 'children'> {}
 
 export default function TeamSelectModal({ openTrigger, ...props }: TeamSelectModalProps) {
 	const { user } = useAuth();
-
-	if (!user) return <LoginModal openTrigger={openTrigger} />;
 
 	return (
 		<Modal variants={user?.type} openTrigger={openTrigger} {...props}>

--- a/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
@@ -4,7 +4,7 @@ import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import TeamSelectModalContent from './ModalContent.tsx';
 
-interface TeamSelectModalProps extends Omit<ModalProps, 'children'> {}
+export interface TeamSelectModalProps extends Omit<ModalProps, 'children'> {}
 
 export default function TeamSelectModal({ openTrigger, ...props }: TeamSelectModalProps) {
 	const { user } = useAuth();

--- a/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import Modal, { ModalProps } from 'src/components/common/Modal.tsx';
+import LoginModal from 'src/components/shared/modal/login/index.tsx';
 import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';
 import TeamSelectModalContent from './ModalContent.tsx';
@@ -9,7 +10,7 @@ interface TeamSelectModalProps extends Omit<ModalProps, 'children'> {}
 export default function TeamSelectModal({ openTrigger, ...props }: TeamSelectModalProps) {
 	const { user } = useAuth();
 
-	// if (!user) return <LoginModal openTrigger={openTrigger} />;
+	if (!user) return <LoginModal openTrigger={openTrigger} />;
 
 	return (
 		<Modal variants={user?.type} openTrigger={openTrigger} {...props}>

--- a/packages/user/src/components/shared/withAuthHOC.tsx
+++ b/packages/user/src/components/shared/withAuthHOC.tsx
@@ -1,0 +1,32 @@
+import React, { PropsWithChildren, ReactElement, useCallback, useState } from 'react';
+import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
+import LoginModal from 'src/components/shared/modal/login/index.tsx';
+import useAuth from 'src/hooks/useAuth.tsx';
+
+interface WithAuthProps {
+	unauthenticatedDisplay: ReactElement;
+}
+
+export default function withAuth<T extends object>(WrappedComponent: React.ComponentType<T>) {
+	return function AuthWrapper({
+		unauthenticatedDisplay,
+		...props
+	}: T & PropsWithChildren<WithAuthProps>) {
+		const { isAuthenticated } = useAuth();
+		const [isUnauthenticatedDisplay, setIsUnauthenticatedDisplay] = useState(false);
+
+		const handleLoginModalClose = useCallback(() => setIsUnauthenticatedDisplay(false), []);
+
+		if (!isAuthenticated || isUnauthenticatedDisplay) {
+			if (!isUnauthenticatedDisplay) setIsUnauthenticatedDisplay(true);
+			return (
+				<LoginModal
+					openTrigger={<TriggerButtonWrapper>{unauthenticatedDisplay}</TriggerButtonWrapper>}
+					onClose={handleLoginModalClose}
+				/>
+			);
+		}
+
+		return <WrappedComponent {...(props as T)} />;
+	};
+}

--- a/packages/user/src/hooks/query/useSubmitLogin.ts
+++ b/packages/user/src/hooks/query/useSubmitLogin.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/naming-convention */
+import { useMutation } from '@tanstack/react-query';
+import useTokenStorage from 'src/hooks/storage/useTokenStorage.ts';
+import useAuth from 'src/hooks/useAuth.tsx';
+import { useToast } from 'src/hooks/useToast.ts';
+import http from 'src/services/api/index.ts';
+
+export type SubmitLoginRequest = { userId: string; password: string };
+
+export interface SubmitLoginResponse {
+	accessToken: string;
+}
+
+const LOGIN_ERROR_TOAST_DESCRIPTION = '문제가 발생했습니다. 다시 시도해주세요.';
+
+export default function useSubmitLogin() {
+	const { setAuthData } = useAuth();
+	const [_, setToken] = useTokenStorage();
+
+	const { toast } = useToast();
+
+	const mutation = useMutation<SubmitLoginResponse, Error, SubmitLoginRequest>({
+		mutationFn: (data: SubmitLoginRequest) => http.post('/login', data),
+		onSuccess: ({ accessToken }, { userId: id }) => {
+			setAuthData({ userData: { id, name: '캐스퍼' } });
+			setToken(accessToken);
+		},
+		onError: () => toast({ description: LOGIN_ERROR_TOAST_DESCRIPTION }),
+	});
+
+	return mutation;
+}

--- a/packages/user/src/hooks/socket/useChatSocket.ts
+++ b/packages/user/src/hooks/socket/useChatSocket.ts
@@ -1,7 +1,7 @@
 import { ChatProps } from '@softeer/common/components';
 import { CHAT_SOCKET_ENDPOINTS } from '@softeer/common/constants';
 import { SocketSubscribeCallbackType } from '@softeer/common/utils';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import useAuth from 'src/hooks/useAuth.tsx';
 import socketClient from 'src/services/socket.ts';
 import type { User } from 'src/types/user.d.ts';
@@ -13,23 +13,29 @@ export default function useChatSocket() {
 
 	const [chatMessages, setChatMessages] = useState<ChatProps[]>([]);
 
-	const handleIncomingMessage: SocketSubscribeCallbackType = (data: unknown, messageId: string) => {
-		const parsedData = data as Omit<ChatProps, 'id'>;
-		const parsedMessage = { id: messageId, ...parsedData };
-		setChatMessages((prevMessages) => [...prevMessages, parsedMessage] as ChatProps[]);
-	};
+	const handleIncomingMessage: SocketSubscribeCallbackType = useCallback(
+		(data: unknown, messageId: string) => {
+			const parsedData = data as Omit<ChatProps, 'id'>;
+			const parsedMessage = { id: messageId, ...parsedData };
+			setChatMessages((prevMessages) => [...prevMessages, parsedMessage] as ChatProps[]);
+		},
+		[],
+	);
 
-	const handleSendMessage = (content: string) => {
-		console.assert(user !== null, '로그인 되지 않은 사용자가 메세지 전송을 시도했습니다.');
+	const handleSendMessage = useCallback(
+		(content: string) => {
+			console.assert(user !== null, '로그인 되지 않은 사용자가 메세지 전송을 시도했습니다.');
 
-		const { id: sender, type: team } = user as NonNullable<User>;
-		const chatMessage = { sender, team, content };
+			const { id: sender, type: team } = user as NonNullable<User>;
+			const chatMessage = { sender, team, content };
 
-		socketClient.sendMessages({
-			destination: CHAT_SOCKET_ENDPOINTS.PUBLISH,
-			body: chatMessage,
-		});
-	};
+			socketClient.sendMessages({
+				destination: CHAT_SOCKET_ENDPOINTS.PUBLISH,
+				body: chatMessage,
+			});
+		},
+		[socketClient],
+	);
 
 	return {
 		onReceiveMessage: handleIncomingMessage,

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -58,11 +58,14 @@ export default function useRacingSocket() {
 	const handleCarFullyCharged = (category: Category) => {
 		const chargeData = { [categoryToSocketCategory[category]]: 1 };
 
-		const completeChargeData = Object.keys(categoryToSocketCategory).reduce((acc, key) => {
-			const socketCategory = categoryToSocketCategory[key as Category];
-			acc[socketCategory] = chargeData[socketCategory] ?? 0;
-			return acc;
-	}, {} as Record<SocketCategory, number>);
+		const completeChargeData = Object.keys(categoryToSocketCategory).reduce(
+			(acc, key) => {
+				const socketCategory = categoryToSocketCategory[key as Category];
+				acc[socketCategory] = chargeData[socketCategory] ?? 0;
+				return acc;
+			},
+			{} as Record<SocketCategory, number>,
+		);
 
 		socketClient.sendMessages({
 			destination: RACING_SOCKET_ENDPOINTS.PUBLISH,

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -48,14 +48,18 @@ export default function useRacingSocket() {
 			setRanks(newRankStatus);
 			storeRank(newRankStatus);
 		}
-	}, [newRankStatus, ranks, storeRank]);
+	}, [newRankStatus, ranks]);
 
 	const handleStatusChange: SocketSubscribeCallbackType = useCallback((data: unknown) => {
 		const newVoteStatus = parseSocketVoteData(data as SocketData);
-		setVotes(newVoteStatus);
-	}, []);
+		const isVotesChanged = Object.keys(newVoteStatus).some(
+			(category) => newVoteStatus[category as Category] !== votes[category as Category],
+	);
 
-	const handleCarFullyCharged = (category: Category) => {
+		if (isVotesChanged) setVotes(newVoteStatus);
+	}, [votes]);
+
+	const handleCarFullyCharged = useCallback((category: Category) => {
 		const chargeData = { [categoryToSocketCategory[category]]: 1 };
 
 		const completeChargeData = Object.keys(categoryToSocketCategory).reduce(
@@ -71,7 +75,7 @@ export default function useRacingSocket() {
 			destination: RACING_SOCKET_ENDPOINTS.PUBLISH,
 			body: completeChargeData,
 		});
-	};
+	}, []);
 
 	return {
 		votes,

--- a/packages/user/src/types/user.d.ts
+++ b/packages/user/src/types/user.d.ts
@@ -1,7 +1,7 @@
 import type { Category } from '@softeer/common/types';
 
 export interface User {
-	id: number;
+	id: string;
 	name: string;
 	type?: Category;
 }

--- a/packages/user/vite.config.ts
+++ b/packages/user/vite.config.ts
@@ -10,7 +10,7 @@ interface VitestConfigExport extends UserConfig {
 
 export default defineConfig({
 	plugins: [react(), svgr(), visualizer()],
-	server: { port: 3000 },
+	// server: { port: 3000 },
 	cacheDir: './.yarn/.vite',
 	test: {
 		globals: true,


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
> 아래 문제"들" 해결하는 데 시간이 좀 걸렸네요
> api 연동 자체는 쉬웠는데 어째 배보다 배꼽이 더 큰 ,,, 느낌,, 

1. 로그인 모달 구현
_-_ OAuth 붙이기 전 token 발급을 위한 로그인 기능이라 DB에 저장된 id, password를 default로 넣어두었습니다. -> 추후 카카오 로그인으로 교체될 예정
_-_ funnel hook 사용해 구현 -> 생각보다 더 잘 쓰는 중이라 뿌듯하네요 

2. 로그인 모달에서 로그인 성공 시 로그인 모달이 강제로 꺼지는 문제
_-_ 로그인하지 않았을 때 기대평 작성이나, 유형 검사, 헤더 내 유저 아이콘 등등.. 많은 부분(이하 `A`)에서 해당 컴포넌트 클릭 시 로그인 모달을 띄워주어야 함
_-_ 별 생각없이 `if (!isAuthenticated) return <LoginModal .../>`와 같이 분기처리를 해줬었는데 이 부분에서 오류 발생
_-_ 로그인 모달에서 로그인이 완료될 경우 login modal 호출 부 상단에서 분기 처리되던 isAuthenticated 값이 true가 됨
_-_ 이 경우 로그인 모달 내 성공 화면이 뜨는 게 아닌, 로그인 모달이 강제로 꺼짐
_-_ 따라서 로그인 모달에서 로그인이 되었더라도 모달이 열린 상태를 유지하는 로직이 각각의 `A`마다 전부 삽입되어야 함
_-_ 동일 로직이 중복됨을 막기 위해 withAuth HOC을 구현해 선언적으로 login 여부를 판단하고, 문제도 해결. 
_-_ 같은 문제가 저번 유형 검사 모달 구현할 때 발생했어서 문제 파악에는 그리 오래 걸리진 않았습니다
_-_ 다만 withAuth를 만족스럽게 구현하는 게 생각보다 오래걸렸네요 , ,, 

3. socket subscribe 값이 trigger 될 때마다(현재 0.5초마다 trigger되도록 설정됨) 하위 전체 컴포넌트가 리렌더링되는 문제
_-_ 단순히 성능상의 문제면 다음 태스크로 넘겼을텐데 리렌더링 시점에 모달이 닫히는 문제도 함께 발생해서.. 무조건 해결했어야 했습니다 ㅜ
_-_ 필요한 최소한 부분을 찾아 해당 로직을 useCallback, memo 등으로 감싸 해결
_-_ 가장 크리티컬했던 부분은 subscribe callback 이었습니다. 

4. withAuth 를 사용해 login 플로우 진행 중에 로그인 성공 시 로그인 모달이 강제로 꺼지는 문제
_-_ 소켓이 연동된 페이지에서 useAuth hook을 호출해 user, isAuthenticated등의 값을 사용중
_-_ user 정보 업데이트 -> 리렌더링 발생 -> login modal 꺼짐
_-_ withAuth를 memo로 감싸고, withAuth로 생성한 wrapper 컴포넌트를 외부에서 선언해 해결

5. form tag 중첩 시 발생하는 submit event propagation 막기
_-_ form tag 내부에서 열리는 모달이 존재 (기대평 채팅)
_-_ 내부 모달에도 form tag가 존재해 모달 내에서 submit할 경우 모달 내부 form tag 뿐만아니라 그 상단 form에도 이벤트 전파
_-_ form id 적용해 매핑해줬는데도 해결되지 않아 당황하고 있었는데 @crongro 님께서 이벤트 전파 가르쳐주신 내용이 문득 떠올라서 바로 해결할 수 있었습니다. 최고 !

6. login API 연동
_-_ 이벤트 페이지 내 첫 API 연동이었는데 잘 연결 됐고, response로 오는 token도 확인 완료
_-_ token cookie에 저장하는 로직은 다음 태스크에서 API 연동할 때 함께 진행할 예정
_-_ CORS error 발생: 어드민 API는 잘 동작한다는 거 알고 있어서 port 3000 -> 5173(어드민)으로 바꾸니 해결됐습니다. 
_-_ 서버에서 port: 5173만 열어두신 것 같네요


<br/>

## 참고 

```ts
import React, { PropsWithChildren, ReactElement, useCallback, useState } from 'react';
import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
import LoginModal from 'src/components/shared/modal/login/index.tsx';
import useAuth from 'src/hooks/useAuth.tsx';

interface WithAuthProps {
	unauthenticatedDisplay: ReactElement;
}

export default function withAuth<T extends object>(WrappedComponent: React.ComponentType<T>) {
	return function AuthWrapper({
		unauthenticatedDisplay,
		...props
	}: T & PropsWithChildren<WithAuthProps>) {
		const { isAuthenticated } = useAuth();
		const [isUnauthenticatedDisplay, setIsUnauthenticatedDisplay] = useState(false);

		const handleLoginModalClose = useCallback(() => setIsUnauthenticatedDisplay(false), []);

		if (!isAuthenticated || isUnauthenticatedDisplay) {
			if (!isUnauthenticatedDisplay) setIsUnauthenticatedDisplay(true);
			return (
				<LoginModal
					openTrigger={<TriggerButtonWrapper>{unauthenticatedDisplay}</TriggerButtonWrapper>}
					onClose={handleLoginModalClose}
				/>
			);
		}

		return <WrappedComponent {...(props as T)} />;
	};
}
```

  <br/>

## 이미지 첨부

<img width="853" alt="스크린샷 2024-08-15 오후 7 34 08" src="https://github.com/user-attachments/assets/6f602d9b-4807-4595-b765-7eb4cc5ae78a">

<img width="841" alt="스크린샷 2024-08-15 오후 7 33 36" src="https://github.com/user-attachments/assets/2c69309f-5ce1-4723-ae3f-5cda4ba237e0">
