### PR TITLE
[Feature][Task-195] 서버 api, socket 연동 테스트 완료

### DIFF
--- a/packages/admin/src/hooks/useAuth.tsx
+++ b/packages/admin/src/hooks/useAuth.tsx
@@ -26,7 +26,7 @@ const useAuth = () => {
 		onSuccess: (data) => {
 			openAlert(InfoMessage.WELCOME, 'alert');
 			navigate(RoutePaths.EVENT_PAGE);
-			Cookie.setCookie(ACCESS_TOKEN_KEY, data.accessToken, 7);
+			Cookie.setCookie<string>(ACCESS_TOKEN_KEY, data.accessToken, 7);
 		},
 		onError: () => {
 			openAlert(ErrorMessage.INVALID_INPUT, 'alert');
@@ -38,7 +38,7 @@ const useAuth = () => {
 	};
 
 	const logout = () => {
-		Cookie.setCookie(ACCESS_TOKEN_KEY, '', 0);
+		Cookie.setCookie<string>(ACCESS_TOKEN_KEY, '', 0);
 		navigate(RoutePaths.ROOT);
 	};
 

--- a/packages/admin/src/hooks/useAuth.tsx
+++ b/packages/admin/src/hooks/useAuth.tsx
@@ -38,7 +38,7 @@ const useAuth = () => {
 	};
 
 	const logout = () => {
-		Cookie.setCookie<string>(ACCESS_TOKEN_KEY, '', 0);
+		Cookie.clearCookie(ACCESS_TOKEN_KEY);
 		navigate(RoutePaths.ROOT);
 	};
 

--- a/packages/admin/src/layouts/appLayout.tsx
+++ b/packages/admin/src/layouts/appLayout.tsx
@@ -15,7 +15,7 @@ export default function AppLayout() {
 	const { headerTitle } = useHeader();
 	const location = useLocation();
 	const navigate = useNavigate();
-	const accessToken = Cookie.getCookie(ACCESS_TOKEN_KEY);
+	const accessToken = Cookie.getCookie<string>(ACCESS_TOKEN_KEY);
 	useEffect(() => {
 		if (location.pathname !== RoutePaths.ROOT) {
 			if (!accessToken) {

--- a/packages/common/src/components/chat/Message.tsx
+++ b/packages/common/src/components/chat/Message.tsx
@@ -1,17 +1,17 @@
 import { PropsWithChildren } from 'react';
 import { MessageChatProps } from 'src/components/chat/index.ts';
-import { Category } from 'src/types/category.ts';
+import { SocketCategory } from 'src/types/category.ts';
 import { cn } from 'src/utils/index.ts';
 
 interface MessageProps extends Pick<MessageChatProps, 'sender' | 'team'> {
 	isMyMessage?: boolean;
 }
 
-const TYPES: Record<Category, { casper: string; textColor: string }> = {
-	pet: { casper: '/casper/yellow.svg', textColor: 'text-cream-600' },
-	leisure: { casper: '/casper/khaki.svg', textColor: 'text-khaki-400' },
-	travel: { casper: '/casper/orange.svg', textColor: 'text-orange-500' },
-	place: { casper: '/casper/white.svg', textColor: 'text-gray-300' },
+const TYPES: Record<SocketCategory, { casper: string; textColor: string }> = {
+	p: { casper: '/casper/yellow.svg', textColor: 'text-cream-600' },
+	l: { casper: '/casper/khaki.svg', textColor: 'text-khaki-400' },
+	t: { casper: '/casper/orange.svg', textColor: 'text-orange-500' },
+	s: { casper: '/casper/white.svg', textColor: 'text-gray-300' },
 };
 
 export default function Message({
@@ -20,7 +20,7 @@ export default function Message({
 	isMyMessage = false,
 	children,
 }: PropsWithChildren<MessageProps>) {
-	const { casper, textColor } = TYPES[team];
+	const { casper, textColor } = TYPES[team.toLowerCase() as SocketCategory];
 
 	return (
 		<div className="flex w-full items-center gap-12">

--- a/packages/common/src/components/chat/index.ts
+++ b/packages/common/src/components/chat/index.ts
@@ -1,4 +1,4 @@
-import { Category } from 'src/types/category.ts';
+import { SocketCategory } from 'src/types/category.ts';
 
 type NoticeChatProps = {
 	id: string;
@@ -13,7 +13,7 @@ export type MessageChatProps = {
 	type: 'm';
 	sender: number;
 	content: string;
-	team: Category;
+	team: SocketCategory;
 };
 
 type BlockedChatProps = {

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -1,3 +1,3 @@
 export { ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY } from './api.ts';
 export { default as CATEGORIES } from './categories.ts';
-export { CHAT_SOCKET_ENDPOINTS, RACING_SOCKET_ENDPOINTS } from './socket.ts';
+export * from './socket.ts';

--- a/packages/common/src/constants/socket.ts
+++ b/packages/common/src/constants/socket.ts
@@ -1,3 +1,5 @@
+import { Category, SocketCategory } from 'src/types/category.ts';
+
 export const CHAT_SOCKET_ENDPOINTS = {
 	SUBSCRIBE: '/topic/chat',
 	PUBLISH: '/app/chat.sendMessage',
@@ -7,3 +9,20 @@ export const RACING_SOCKET_ENDPOINTS = {
 	SUBSCRIBE: '/topic/game',
 	PUBLISH: '/app/game.sendGameData',
 } as const;
+
+/**
+ * Mapping between Category and SocketCategory
+ */
+export const categoryToSocketCategory: Record<Category, SocketCategory> = {
+	pet: 'p',
+	travel: 't',
+	place: 's',
+	leisure: 'l',
+};
+
+export const socketCategoryToCategory: Record<SocketCategory, Category> = {
+	p: 'pet',
+	t: 'travel',
+	s: 'place',
+	l: 'leisure',
+};

--- a/packages/common/src/types/category.ts
+++ b/packages/common/src/types/category.ts
@@ -1,3 +1,4 @@
 import CATEGORIES from 'src/constants/categories.ts';
 
 export type Category = (typeof CATEGORIES)[number];
+export type SocketCategory = 'p' | 't' | 's' | 'l';

--- a/packages/common/src/utils/api/index.ts
+++ b/packages/common/src/utils/api/index.ts
@@ -1,7 +1,6 @@
 import { ACCESS_TOKEN_KEY } from 'src/constants/api.ts';
-import getCookie from '../storage/cookie/getCookie.ts';
-// eslint-disable-next-line import/no-cycle
-import fetchWithInterceptors from './fetchInterceptors.ts';
+import fetchWithInterceptors from 'src/utils/api/fetchInterceptors.ts';
+import getCookie from 'src/utils/storage/cookie/getCookie.ts';
 
 interface Interceptors {
 	request?: (url: string, options: RequestInit) => Promise<RequestInit> | RequestInit;
@@ -12,7 +11,7 @@ export function generateDefaultHeaders(): HeadersInit {
 	const headers: HeadersInit = {
 		'Content-Type': 'application/json',
 	};
-	const accessToken = getCookie(ACCESS_TOKEN_KEY);
+	const accessToken = getCookie<string>(ACCESS_TOKEN_KEY);
 	if (accessToken) {
 		headers.Authorization = accessToken;
 	}

--- a/packages/common/src/utils/storage/cookie/clearCookie.ts
+++ b/packages/common/src/utils/storage/cookie/clearCookie.ts
@@ -1,0 +1,5 @@
+function clearCookie(name: string): void {
+	document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}
+
+export default clearCookie;

--- a/packages/common/src/utils/storage/cookie/getCookie.ts
+++ b/packages/common/src/utils/storage/cookie/getCookie.ts
@@ -1,13 +1,13 @@
-function getCookie<T>(name: string):T | null {
+function getCookie<T>(name: string): T | null {
 	const cookies = document.cookie.split('; ');
 	if (cookies.length === 1 && cookies[0] === '') {
 		return null;
 	}
-	let returnValue = null;
+	let returnValue: T | null = null;
 	cookies.some((cookie) => {
 		const [key, value] = cookie.split('=');
 		if (key === name) {
-			returnValue = value;
+			returnValue = JSON.parse(value);
 			return true;
 		}
 		return false;

--- a/packages/common/src/utils/storage/cookie/getCookie.ts
+++ b/packages/common/src/utils/storage/cookie/getCookie.ts
@@ -1,4 +1,4 @@
-function getCookie(name: string) {
+function getCookie<T>(name: string):T | null {
 	const cookies = document.cookie.split('; ');
 	if (cookies.length === 1 && cookies[0] === '') {
 		return null;

--- a/packages/common/src/utils/storage/cookie/getCookie.ts
+++ b/packages/common/src/utils/storage/cookie/getCookie.ts
@@ -14,4 +14,5 @@ function getCookie<T>(name: string):T | null {
 	});
 	return returnValue;
 }
+
 export default getCookie;

--- a/packages/common/src/utils/storage/cookie/index.ts
+++ b/packages/common/src/utils/storage/cookie/index.ts
@@ -1,4 +1,5 @@
+import clearCookie from './clearCookie.ts';
 import getCookie from './getCookie.ts';
 import setCookie from './setCookie.ts';
 
-export default { getCookie, setCookie };
+export default { getCookie, setCookie, clearCookie };

--- a/packages/common/src/utils/storage/cookie/setCookie.ts
+++ b/packages/common/src/utils/storage/cookie/setCookie.ts
@@ -1,10 +1,10 @@
 const DAY = 24 * 60 * 60 * 1000;
 
-function setCookie<T>(key: string, value: T, expirationDays: number = 7):undefined {
+function setCookie<T>(name: string, value: T, expirationDays: number = 7):void {
 	const date = new Date();
 	date.setTime(date.getTime() + expirationDays * DAY);
 	const		expires = `; expires=${date.toUTCString()}`;
-	document.cookie = `${key}=${JSON.stringify(value) || ''}${expires}; path=/`;
+	document.cookie = `${name}=${JSON.stringify(value) || ''}${expires}; path=/`;
 }
 
 export default setCookie;

--- a/packages/common/src/utils/storage/cookie/setCookie.ts
+++ b/packages/common/src/utils/storage/cookie/setCookie.ts
@@ -1,9 +1,9 @@
 const DAY = 24 * 60 * 60 * 1000;
 
-function setCookie<T>(name: string, value: T, expirationDays: number = 7):void {
+function setCookie<T>(name: string, value: T, expirationDays: number = 7): void {
 	const date = new Date();
 	date.setTime(date.getTime() + expirationDays * DAY);
-	const		expires = `; expires=${date.toUTCString()}`;
+	const expires = `; expires=${date.toUTCString()}`;
 	document.cookie = `${name}=${JSON.stringify(value) || ''}${expires}; path=/`;
 }
 

--- a/packages/common/src/utils/storage/cookie/setCookie.ts
+++ b/packages/common/src/utils/storage/cookie/setCookie.ts
@@ -1,11 +1,10 @@
-function setCookie(name: string, value: string, days: number) {
-	let expires = '';
-	if (days) {
-		const date = new Date();
-		date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
-		expires = `; expires=${date.toUTCString()}`;
-	}
-	document.cookie = `${name}=${value || ''}${expires}; path=/`;
+const DAY = 24 * 60 * 60 * 1000;
+
+function setCookie<T>(key: string, value: T, expirationDays: number = 7):undefined {
+	const date = new Date();
+	date.setTime(date.getTime() + expirationDays * DAY);
+	const		expires = `; expires=${date.toUTCString()}`;
+	document.cookie = `${key}=${JSON.stringify(value) || ''}${expires}; path=/`;
 }
 
 export default setCookie;

--- a/packages/common/src/utils/storage/index.ts
+++ b/packages/common/src/utils/storage/index.ts
@@ -1,3 +1,3 @@
-import cookie from './cookie/index.ts';
+import Cookie from './cookie/index.ts';
 
-export default cookie;
+export default Cookie;

--- a/packages/user/src/components/common/toast/Toast.tsx
+++ b/packages/user/src/components/common/toast/Toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
 	<ToastPrimitives.Viewport
 		ref={ref}
 		className={cn(
-			'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-10 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[500px]',
+			'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-10 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[500px] gap-4',
 			className,
 		)}
 		{...props}
@@ -86,5 +86,5 @@ export {
 	ToastProvider,
 	ToastViewport,
 	type ToastActionElement,
-	type ToastProps,
+	type ToastProps
 };

--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -1,5 +1,4 @@
 import { ChatList } from '@softeer/common/components';
-import { memo } from 'react';
 import ChatInput from 'src/components/event/chatting/inputArea/input/index.tsx';
 import { UseChatSocketReturnType } from 'src/hooks/socket/useChatSocket.ts';
 import Chat from './Chat.tsx';
@@ -7,8 +6,8 @@ import ChatInputArea from './inputArea/index.tsx';
 
 /** 실시간 기대평 섹션 */
 
-const RealTimeChatting = memo(({ onSendMessage, messages }: UseChatSocketReturnType) => (
-	<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
+function RealTimeChatting({ onSendMessage, messages }: UseChatSocketReturnType) {
+  return <section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
 		<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>
 		<ChatInputArea>
 			<ChatInput onSend={onSendMessage} />
@@ -20,7 +19,7 @@ const RealTimeChatting = memo(({ onSendMessage, messages }: UseChatSocketReturnT
 				))}
 			</ChatList>
 		</div>
-	</section>
-));
+         </section>;
+}
 
 export default RealTimeChatting;

--- a/packages/user/src/components/event/chatting/inputArea/input/index.tsx
+++ b/packages/user/src/components/event/chatting/inputArea/input/index.tsx
@@ -17,21 +17,24 @@ export default function ChatInput({ onSend }: ChatInputProps) {
 
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	const handleSubmit = useCallback((event: React.FormEvent<HTMLFormElement>) => {
-		event.preventDefault();
+	const handleSubmit = useCallback(
+		(event: React.FormEvent<HTMLFormElement>) => {
+			event.preventDefault();
 
-		const disabledChatting = !isAuthenticated;
+			const disabledChatting = !isAuthenticated;
 
-		if (disabledChatting) {
-			toast({ description: DISABLED_CHATTING_TOAST_DESCRIPTION });
-			return;
-		}
+			if (disabledChatting) {
+				toast({ description: DISABLED_CHATTING_TOAST_DESCRIPTION });
+				return;
+			}
 
-		if (inputRef.current?.value) {
-			onSend(inputRef.current.value);
-			inputRef.current.value = '';
-		}
-	}, [isAuthenticated]);
+			if (inputRef.current?.value) {
+				onSend(inputRef.current.value);
+				inputRef.current.value = '';
+			}
+		},
+		[isAuthenticated],
+	);
 
 	return (
 		<form className="flex items-center gap-4" onSubmit={handleSubmit}>

--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -1,6 +1,6 @@
 import { Category } from '@softeer/common/types';
 import numeral from 'numeral';
-import { memo, useMemo } from 'react';
+import { useMemo } from 'react';
 import { TEAM_DESCRIPTIONS } from 'src/constants/teamDescriptions.ts';
 import type { ChargeButtonData } from './ControlButton.tsx';
 
@@ -8,7 +8,8 @@ interface ChargeButtonContentProps extends ChargeButtonData {
 	type: Category;
 }
 
-const ChargeButtonContent = memo(({ rank, vote, type, percentage }: ChargeButtonContentProps) => {
+export default function ChargeButtonContent({
+	rank, vote, type, percentage }: ChargeButtonContentProps) {
 	const { shortTitle, title } = TEAM_DESCRIPTIONS[type];
 	const displayTitle = shortTitle ?? title;
 	const displayVoteStats = useMemo(() => `${percentage.toFixed(1)}% (${formatVoteCount(vote)})`, [percentage, vote]);
@@ -22,9 +23,7 @@ const ChargeButtonContent = memo(({ rank, vote, type, percentage }: ChargeButton
 			</div>
 		</>
 	);
-});
-
-export default ChargeButtonContent;
+}
 
 /** Utility Functions */
 function formatVoteCount(count: number): string {

--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -17,7 +17,7 @@ const ChargeButtonContent = memo(({ rank, vote, type }: ChargeButtonContentProps
 		<>
 			<h2 className="pt-2">{rank}</h2>
 			<div className="flex flex-col items-center">
-				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{formattedVote}%</p>
+				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{formattedVote}</p>
 				<h6>{displayTitle}</h6>
 			</div>
 		</>

--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -4,20 +4,20 @@ import { memo, useMemo } from 'react';
 import { TEAM_DESCRIPTIONS } from 'src/constants/teamDescriptions.ts';
 import type { ChargeButtonData } from './ControlButton.tsx';
 
-interface ChargeButtonContentProps extends Omit<ChargeButtonData, 'percentage'> {
+interface ChargeButtonContentProps extends ChargeButtonData {
 	type: Category;
 }
 
-const ChargeButtonContent = memo(({ rank, vote, type }: ChargeButtonContentProps) => {
+const ChargeButtonContent = memo(({ rank, vote, type, percentage }: ChargeButtonContentProps) => {
 	const { shortTitle, title } = TEAM_DESCRIPTIONS[type];
 	const displayTitle = shortTitle ?? title;
-	const formattedVote = useMemo(() => formatVoteCount(vote), [vote]);
+	const displayVoteStats = useMemo(() => `${percentage.toFixed(1)}% (${formatVoteCount(vote)})`, [percentage, vote]);
 
 	return (
 		<>
 			<h2 className="pt-2">{rank}</h2>
 			<div className="flex flex-col items-center">
-				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{formattedVote}</p>
+				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{displayVoteStats}</p>
 				<h6>{displayTitle}</h6>
 			</div>
 		</>

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -1,5 +1,6 @@
 import type { Category } from '@softeer/common/types';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import useAuth from 'src/hooks/useAuth.tsx';
 import { useToast } from 'src/hooks/useToast.ts';
 import type { Rank } from 'src/types/racing.d.ts';
 import ChargeButtonContent from './ChargeButtonContent.tsx';
@@ -11,7 +12,7 @@ const MAX_CLICK = 10;
 const MIN_PERCENT = 2;
 const RESET_SECOND = 10000;
 const MAX_CLICK_TOAST_DESCRIPTION = '배터리가 떨어질 때까지 기다려주세요!';
-
+const DISABLED_RACING_TOAST_DESCRIPTION = '로그인 후 레이싱에 참여할 수 있습니다!';
 interface ControlButtonProps {
 	type: Category;
 	data: ChargeButtonData;
@@ -25,7 +26,8 @@ export interface ChargeButtonData {
 	percentage: number;
 }
 
-const ControlButton = memo(({ onCharge, onFullyCharged, type, data }: ControlButtonProps) => {
+export default function ControlButton({
+	onCharge, onFullyCharged, type, data }: ControlButtonProps) {
 	const { rank, percentage } = data;
 	const { progress, clickCount, handleClick } = useGaugeProgress({
 		percentage,
@@ -41,9 +43,7 @@ const ControlButton = memo(({ onCharge, onFullyCharged, type, data }: ControlBut
 			</ChargeButtonWrapper>
 		</ControllButtonWrapper>
 	);
-});
-
-export default ControlButton;
+}
 
 /** Custom Hook */
 function useGaugeProgress({
@@ -56,18 +56,21 @@ function useGaugeProgress({
 	onFullyCharged: () => void;
 }) {
 	const { toast } = useToast();
+	const { isAuthenticated } = useAuth();
 	const [progress, setProgress] = useState(percentage);
 	const [clickCount, setClickCount] = useState(0);
 
 	const updateProgress = useCallback((count: number) => {
 		const newProgress = calculateProgress(count);
-		setProgress(newProgress);
-	}, []);
+		if (progress !== newProgress)setProgress(newProgress);
+}, [progress]);
 
 	const resetProgress = useCallback(() => {
 		setClickCount(0);
 		setProgress(percentage);
 	}, [percentage]);
+
+	useEffect(() => setProgress(percentage), [percentage]);
 
 	useEffect(() => {
 		if (clickCount > 0 && clickCount <= MAX_CLICK) {
@@ -75,12 +78,16 @@ function useGaugeProgress({
 		}
 
 		if (clickCount === MAX_CLICK) {
-			onFullyCharged();
+			if (!isAuthenticated) {
+				toast({ description: DISABLED_RACING_TOAST_DESCRIPTION });
+			} else {
+				onFullyCharged();
+			}
 			toast({ description: MAX_CLICK_TOAST_DESCRIPTION });
 			const resetTimer = setTimeout(resetProgress, RESET_SECOND);
 			return () => clearTimeout(resetTimer);
 		}
-	}, [clickCount]);
+	}, [clickCount, isAuthenticated]);
 
 	const handleClick = useCallback(() => {
 		if (clickCount < MAX_CLICK) {

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -62,7 +62,7 @@ function useGaugeProgress({
 
 	const updateProgress = useCallback((count: number) => {
 		const newProgress = calculateProgress(count);
-		if (progress !== newProgress)setProgress(newProgress);
+		setProgress(newProgress);
 }, [progress]);
 
 	const resetProgress = useCallback(() => {

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import Lightning from 'src/assets/icons/lighting.svg?react';
 
 interface GaugeProps {
 	percent: number;
 }
-export default function Gauge({ percent }: GaugeProps) {
+const Gauge = memo(({ percent }: GaugeProps) => {
 	const backgroundColor = useMemo(() => {
 		if (percent < 22) return 'bg-gradient-gauge1';
 		if (percent < 57) return 'bg-gradient-gauge2';
@@ -18,9 +18,10 @@ export default function Gauge({ percent }: GaugeProps) {
 			<div className="relative h-[4px] w-full rounded-[2px] bg-neutral-600">
 				<div
 					className={`ease-&lsqb;cubic-bezier(0.14,0.63,0.82,0.72)&rsqb; absolute z-10 h-full transform rounded-[2px] transition-all duration-700 ${backgroundColor}`}
-					style={{ width: `${percent}%` }}
+					style={{ width: `${percent.toFixed(0)}%` }}
 				/>
 			</div>
 		</div>
 	);
-}
+});
+export default Gauge;

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -1,10 +1,10 @@
-import { memo, useMemo } from 'react';
+import { useMemo } from 'react';
 import Lightning from 'src/assets/icons/lighting.svg?react';
 
 interface GaugeProps {
 	percent: number;
 }
-const Gauge = memo(({ percent }: GaugeProps) => {
+export default function Gauge({ percent }: GaugeProps) {
 	const backgroundColor = useMemo(() => {
 		if (percent < 22) return 'bg-gradient-gauge1';
 		if (percent < 57) return 'bg-gradient-gauge2';
@@ -23,5 +23,4 @@ const Gauge = memo(({ percent }: GaugeProps) => {
 			</div>
 		</div>
 	);
-});
-export default Gauge;
+}

--- a/packages/user/src/components/event/racing/dashboard/card/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/index.tsx
@@ -1,7 +1,9 @@
 import { Category } from '@softeer/common/types';
 import { memo, useState } from 'react';
 import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
-import TeamSelectModal, { type TeamSelectModalProps } from 'src/components/shared/modal/teamSelectModal/index.tsx';
+import TeamSelectModal, {
+	type TeamSelectModalProps,
+} from 'src/components/shared/modal/teamSelectModal/index.tsx';
 import ShareCountTeamCard from 'src/components/shared/ShareCountTeamCard.tsx';
 import withAuth from 'src/components/shared/withAuthHOC.tsx';
 import useAuth from 'src/hooks/useAuth.tsx';

--- a/packages/user/src/components/event/racing/dashboard/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { CATEGORIES } from '@softeer/common/constants';
 import type { Category } from '@softeer/common/types';
-import { Suspense, memo } from 'react';
+import { Suspense } from 'react';
 import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import Background from './Background.tsx';
 import RacingCard from './card/index.tsx';
@@ -12,8 +12,8 @@ interface RacingDashboardProps extends Pick<UseRacingSocketReturnType, 'ranks'> 
 	chargedCar: Category | null;
 }
 
-const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
-		<div className="relative h-[685px] w-full">
+export default function RacingDashboard({ ranks, chargedCar }: RacingDashboardProps) {
+  return <div className="relative h-[685px] w-full">
 			<HeaderSection />
 			<RacingCardSection />
 			{CATEGORIES.map((type) => (
@@ -25,10 +25,9 @@ const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
 				/>
 			))}
 			<Background />
-		</div>
-	));
+         </div>;
+}
 
-export default RacingDashboard;
 function HeaderSection() {
 	return (
 		<div className="absolute -top-[5px] flex w-full flex-col items-center">

--- a/packages/user/src/components/event/racing/dashboard/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { CATEGORIES } from '@softeer/common/constants';
 import type { Category } from '@softeer/common/types';
-import { Suspense } from 'react';
+import { Suspense, memo } from 'react';
 import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import Background from './Background.tsx';
 import RacingCard from './card/index.tsx';
@@ -12,8 +12,7 @@ interface RacingDashboardProps extends Pick<UseRacingSocketReturnType, 'ranks'> 
 	chargedCar: Category | null;
 }
 
-export default function RacingDashboard({ ranks, chargedCar }: RacingDashboardProps) {
-	return (
+const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
 		<div className="relative h-[685px] w-full">
 			<HeaderSection />
 			<RacingCardSection />
@@ -27,9 +26,9 @@ export default function RacingDashboard({ ranks, chargedCar }: RacingDashboardPr
 			))}
 			<Background />
 		</div>
-	);
-}
+	));
 
+export default RacingDashboard;
 function HeaderSection() {
 	return (
 		<div className="absolute -top-[5px] flex w-full flex-col items-center">

--- a/packages/user/src/components/event/racing/dashboard/timer/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/timer/index.tsx
@@ -11,7 +11,7 @@ interface TimeLeft {
 
 export default function EventTimer() {
 	const {
-		duration: { endDate },
+		duration: { endTime: endDate },
 	} = useGetEventDuration();
 
 	const [timeLeft, setTimeLeft] = useState<TimeLeft>(calculateTimeLeft(endDate));

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -1,12 +1,12 @@
 import { Category } from '@softeer/common/types';
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import RacingControls from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
-export default function RealTimeRacing(racingSocket: UseRacingSocketReturnType) {
+ const RealTimeRacing = memo((racingSocket: UseRacingSocketReturnType) => {
 	const [chargedCar, setChargedCar] = useState<Category | null>(null);
 
 	const { ranks, votes, onCarFullyCharged } = racingSocket;
@@ -25,4 +25,5 @@ export default function RealTimeRacing(racingSocket: UseRacingSocketReturnType) 
 			/>
 		</section>
 	);
-}
+});
+export default RealTimeRacing;

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -1,12 +1,12 @@
 import { Category } from '@softeer/common/types';
-import { memo, useState } from 'react';
+import { useState } from 'react';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import RacingControls from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
- const RealTimeRacing = memo((racingSocket: UseRacingSocketReturnType) => {
+export default function RealTimeRacing(racingSocket: UseRacingSocketReturnType) {
 	const [chargedCar, setChargedCar] = useState<Category | null>(null);
 
 	const { ranks, votes, onCarFullyCharged } = racingSocket;
@@ -25,5 +25,4 @@ import RacingDashboard from './dashboard/index.tsx';
 			/>
 		</section>
 	);
-});
-export default RealTimeRacing;
+}

--- a/packages/user/src/components/home/eventHero/EventDurationText.tsx
+++ b/packages/user/src/components/home/eventHero/EventDurationText.tsx
@@ -10,7 +10,7 @@ export default function EventDurationText() {
 
 /* utils */
 
-function formatDateRange({ startDate, endDate }: EventDurationType): string {
+function formatDateRange({ startTime: startDate, endTime: endDate }: EventDurationType): string {
 	const timeOptions: Intl.DateTimeFormatOptions = {
 		hour: '2-digit',
 		minute: '2-digit',

--- a/packages/user/src/components/home/eventHero/LandingTitle.tsx
+++ b/packages/user/src/components/home/eventHero/LandingTitle.tsx
@@ -13,7 +13,7 @@ export default function LandingTitle() {
 			</Subtitle>
 			<div className="flex items-center gap-3">
 				<Chip>이벤트 기간</Chip>
-				<p className="text-detail-1 h-[22px] w-[160px]">
+				<p className="text-detail-1 h-[22px] w-[180px] min-w-max">
 					<Suspense fallback="불러오는 중...">
 						<EventDurationText />
 					</Suspense>

--- a/packages/user/src/components/shared/modal/fcfs/ErrorStep.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/ErrorStep.tsx
@@ -4,9 +4,7 @@ import InfoStep from 'src/components/shared/modal/InfoStep.tsx';
 import ResultStep from './ResultStep.tsx';
 
 export default function ErrorStep({ error, resetErrorBoundary }: FallbackProps) {
-	const { status } = error.response;
-
-	switch (status) {
+	switch (error.status) {
 		case 410:
 			return <ResultStep step="already-done" />;
 		case 403:
@@ -18,7 +16,24 @@ export default function ErrorStep({ error, resetErrorBoundary }: FallbackProps) 
 					</Button>
 				</InfoStep>
 			);
+		case 404:
+			return (
+				<InfoStep>
+					<p className="text-heading-10 font-medium">오늘 날짜에 해당하는 퀴즈가 없어요</p>
+					<p className="text-body-3 text-neutral-200">
+						문제가 발생하였습니다. 관리자에게 문의해주세요
+					</p>
+				</InfoStep>
+			);
 		default:
-			return null;
+			console.error(error);
+			return (
+				<InfoStep>
+					<p className="text-heading-10 font-medium">선착순 퀴즈 정보를 불러올 수 없어요</p>
+					<p className="text-body-3 text-neutral-200">
+						문제가 발생하였습니다. 관리자에게 문의해주세요
+					</p>
+				</InfoStep>
+			);
 	}
 }

--- a/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
+++ b/packages/user/src/components/shared/modal/fcfs/QuizStep.tsx
@@ -51,6 +51,7 @@ function getResultStepFromStatus({ status }: SubmitFCFSQuizResponse) {
 			return 'already-done';
 		case 'WRONG':
 			return 'wrong-answer';
+		case 'RIGHT':
 		default:
 			return 'correct-answer';
 	}

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -32,7 +32,9 @@ export default function LoginStep({ onSuccess }: LoginStepProps) {
 			className="flex h-full w-full flex-col items-center justify-center gap-12"
 		>
 			<p className="text-heading-9 text-center font-bold">
-				이벤트 참여를 위해<br /><strong>로그인</strong>을 진행해주세요
+				이벤트 참여를 위해
+				<br />
+				<strong>로그인</strong>을 진행해주세요
 			</p>
 			<div className="flex flex-col items-center justify-center gap-5">
 				<input

--- a/packages/user/src/components/shared/modal/login/SuccessStep.tsx
+++ b/packages/user/src/components/shared/modal/login/SuccessStep.tsx
@@ -1,14 +1,18 @@
 import useAuth from 'src/hooks/useAuth.tsx';
 
 export default function SuccessStep() {
-  const { user } = useAuth();
-  const displayName = user?.name ?? '사용자';
+	const { user } = useAuth();
+	const displayName = user?.name ?? '사용자';
 
-  return (
-    <div className="flex flex-col items-center justify-center p-[20px] h-full">
-			<img src="/images/fcfs/result/correct.png" alt="로그인 성공 캐스퍼 캐릭터" className="h-[300px] object-contain" />
-			<p className="text-body-1 font-medium text-primary">로그인 완료</p>
+	return (
+		<div className="flex h-full flex-col items-center justify-center p-[20px]">
+			<img
+				src="/images/fcfs/result/correct.png"
+				alt="로그인 성공 캐스퍼 캐릭터"
+				className="h-[300px] object-contain"
+			/>
+			<p className="text-body-1 text-primary font-medium">로그인 완료</p>
 			<p className="text-heading-7 font-bold">{displayName}님 환영합니다!</p>
-    </div>
-  );
+		</div>
+	);
 }

--- a/packages/user/src/components/shared/modal/login/index.tsx
+++ b/packages/user/src/components/shared/modal/login/index.tsx
@@ -16,7 +16,9 @@ export default function LoginModal({ openTrigger, ...props }: LoginModalProps) {
 				<Funnel.Step name="login">
 					<LoginStep onSuccess={() => setStep('success')} />
 				</Funnel.Step>
-				<Funnel.Step name="success"><SuccessStep /></Funnel.Step>
+				<Funnel.Step name="success">
+					<SuccessStep />
+				</Funnel.Step>
 			</Funnel>
 		</Modal>
 	);

--- a/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
@@ -1,6 +1,5 @@
 import { Suspense, useEffect, useState } from 'react';
 import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
-import useGetTeamTypeQuizzes from 'src/hooks/query/useGetTeamTypeQuiz.ts';
 import useSubmitTeamTypeQuizAnswers, {
 	type SubmitQuizAnswersRequest,
 	type SubmitQuizAnswersResponse,
@@ -18,7 +17,6 @@ export default function TeamSelectModalContent() {
 		'error',
 	] as NonEmptyArray<string>);
 
-	const { quizzes } = useGetTeamTypeQuizzes();
 	const { mutate: submitAnswers, isPending } = useSubmitTeamTypeQuizAnswers();
 
 	const [result, setResult] = useState<SubmitQuizAnswersResponse | null>(null);
@@ -41,7 +39,7 @@ export default function TeamSelectModalContent() {
 		<Funnel>
 			<Funnel.Step name="quiz">
 				<Suspense fallback={<PendingStep>유형 검사 리스트 불러오는 중 ...</PendingStep>}>
-					<QuizFunnel quizzes={quizzes} onSubmit={handleSubmit} />
+					<QuizFunnel onSubmit={handleSubmit} />
 				</Suspense>
 			</Funnel.Step>
 			<Funnel.Step name="pending">

--- a/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
@@ -1,8 +1,7 @@
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 import PendingStep from 'src/components/shared/modal/PendingStep.tsx';
 import useSubmitTeamTypeQuizAnswers, {
 	type SubmitQuizAnswersRequest,
-	type SubmitQuizAnswersResponse,
 } from 'src/hooks/query/useSubmitTeamTypeQuizAnswers.ts';
 import useFunnel from 'src/hooks/useFunnel.ts';
 import ErrorStep from './ErrorStep.tsx';
@@ -19,21 +18,15 @@ export default function TeamSelectModalContent() {
 
 	const { mutate: submitAnswers, isPending } = useSubmitTeamTypeQuizAnswers();
 
-	const [result, setResult] = useState<SubmitQuizAnswersResponse | null>(null);
-
 	const handleSubmit = (request: SubmitQuizAnswersRequest) =>
 		submitAnswers(request, {
-			onSuccess: setResult,
+			onSuccess: () => setStep('success'),
 			onError: () => setStep('error'),
 		});
 
 	useEffect(() => {
 		if (isPending) setStep('pending');
 	}, [isPending]);
-
-	useEffect(() => {
-		if (result) setStep('success');
-	}, [result]);
 
 	return (
 		<Funnel>
@@ -46,7 +39,7 @@ export default function TeamSelectModalContent() {
 				<PendingStep>내 유형 불러오는 중 ...</PendingStep>
 			</Funnel.Step>
 			<Funnel.Step name="success">
-				<ResultStep {...(result as NonNullable<SubmitQuizAnswersResponse>)} />
+				<ResultStep />
 			</Funnel.Step>
 			<Funnel.Step name="error">
 				<ErrorStep setQuizStep={() => setStep('quiz')}>유형 검사 결과를 잃어버렸어요...</ErrorStep>

--- a/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
@@ -1,13 +1,15 @@
 import { Category } from '@softeer/common/types';
-import { FunctionComponent, PropsWithChildren } from 'react';
+import { FunctionComponent, PropsWithChildren, useMemo } from 'react';
 import LinkShare from 'src/components/shared/linkShare/index.tsx';
 import ShareCountTeamCard from 'src/components/shared/ShareCountTeamCard.tsx';
 import { TEAM_DESCRIPTIONS } from 'src/constants/teamDescriptions.ts';
-import type { SubmitQuizAnswersResponse } from 'src/hooks/query/useSubmitTeamTypeQuizAnswers.ts';
+import useAuth from 'src/hooks/useAuth.tsx';
 
-interface ResultStepProps extends SubmitQuizAnswersResponse {}
+export default function ResultStep() {
+	const { user } = useAuth();
 
-export default function ResultStep({ team: type }: ResultStepProps) {
+	const type = useMemo(() => (user?.type as Category), [user]);
+
 	const { title, shortTitle, details } = TEAM_DESCRIPTIONS[type];
 	const displayTitle = shortTitle ?? title;
 

--- a/packages/user/src/components/shared/modal/teamSelectModal/quiz/QuizStepContent.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/quiz/QuizStepContent.tsx
@@ -21,7 +21,7 @@ export default function QuizStepContent({
 				{question}
 			</p>
 			<ul className="my-8 flex w-full min-w-[300px] max-w-[400px] flex-col items-center gap-4">
-				{choices.map(({ text }, choiceIndex) => (
+				{choices.map((text, choiceIndex) => (
 					<li className="w-full" key={text}>
 						<OptionButton
 							isActive={selectedChoice === choiceIndex}

--- a/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
@@ -17,7 +17,7 @@ export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
 
 	const [Funnel, setStep] = useFunnel(steps);
 
-	const [answers, setAnswers] = useState<SubmitQuizAnswersRequest>({});
+	const [answers, setAnswers] = useState<Record<number, number>>({});
 
 	const handleNavigation = useCallback(
 		(quizIndex: number, direction: 'previous' | 'next') => {
@@ -39,6 +39,8 @@ export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
 		},
 		[steps, handleNavigation],
 	);
+
+	const handleSubmit = useCallback(() => onSubmit(transformRecordToArray(answers)), [answers]);
 
 	return (
 		<Funnel>
@@ -73,7 +75,7 @@ export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
 									<Button
 										className="flex-1"
 										disabled={disabledNextButton}
-										onClick={() => onSubmit(answers)}
+										onClick={handleSubmit}
 									>
 										결과 보기
 									</Button>
@@ -95,6 +97,8 @@ export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
 	);
 }
 
+/** Components */
+
 function StepWrapper({ children }: PropsWithChildren) {
 	return (
 		<div className="py-15 flex h-full flex-col items-center justify-center gap-4">{children}</div>
@@ -103,4 +107,12 @@ function StepWrapper({ children }: PropsWithChildren) {
 
 function ActionsWrapper({ children }: PropsWithChildren) {
 	return <div className="flex w-full min-w-[250px] max-w-[350px] gap-3">{children}</div>;
+}
+
+/** Helper Function */
+function transformRecordToArray(record: Record<number, number>): SubmitQuizAnswersRequest {
+	return Object.entries(record).map(([id, answer]) => ({
+			id: Number(id),
+			answer,
+	}));
 }

--- a/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
@@ -72,11 +72,7 @@ export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
 									</Button>
 								)}
 								{isLastQuestion ? (
-									<Button
-										className="flex-1"
-										disabled={disabledNextButton}
-										onClick={handleSubmit}
-									>
+									<Button className="flex-1" disabled={disabledNextButton} onClick={handleSubmit}>
 										결과 보기
 									</Button>
 								) : (
@@ -112,7 +108,7 @@ function ActionsWrapper({ children }: PropsWithChildren) {
 /** Helper Function */
 function transformRecordToArray(record: Record<number, number>): SubmitQuizAnswersRequest {
 	return Object.entries(record).map(([id, answer]) => ({
-			id: Number(id),
-			answer,
+		id: Number(id),
+		answer,
 	}));
 }

--- a/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/quiz/index.tsx
@@ -1,17 +1,18 @@
 import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
 import Button from 'src/components/common/Button.tsx';
 import StepProgress from 'src/components/common/StepProgress.tsx';
-import { Quiz } from 'src/hooks/query/useGetTeamTypeQuiz.ts';
+import useGetTeamTypeQuizzes from 'src/hooks/query/useGetTeamTypeQuiz.ts';
 import { SubmitQuizAnswersRequest } from 'src/hooks/query/useSubmitTeamTypeQuizAnswers.ts';
 import useFunnel from 'src/hooks/useFunnel.ts';
 import QuizStepContent from './QuizStepContent.tsx';
 
 interface QuizFunnelProps {
-	quizzes: Quiz[];
 	onSubmit: (data: SubmitQuizAnswersRequest) => void;
 }
 
-export default function QuizFunnel({ quizzes, onSubmit }: QuizFunnelProps) {
+export default function QuizFunnel({ onSubmit }: QuizFunnelProps) {
+	const { quizzes } = useGetTeamTypeQuizzes();
+
 	const steps = useMemo(() => quizzes.map((q) => q.id) as NonEmptyArray<number>, [quizzes]);
 
 	const [Funnel, setStep] = useFunnel(steps);

--- a/packages/user/src/constants/storageKey.ts
+++ b/packages/user/src/constants/storageKey.ts
@@ -1,8 +1,10 @@
+import { ACCESS_TOKEN_KEY } from '@softeer/common/constants';
+
 const STORAGE_KEY_PREFIX = 'hyundai-softeer-team4';
 
 const STORAGE_KEYS = {
+	TOKEN: ACCESS_TOKEN_KEY,
 	USER: `${STORAGE_KEY_PREFIX}-user`,
-	TOKEN: `${STORAGE_KEY_PREFIX}-token`,
 	RANK: `${STORAGE_KEY_PREFIX}-rank`,
 } as const;
 

--- a/packages/user/src/context/auth/index.tsx
+++ b/packages/user/src/context/auth/index.tsx
@@ -4,14 +4,14 @@ import useUserStorage from 'src/hooks/storage/useUserStorage.ts';
 import type { User } from 'src/types/user.d.ts';
 
 export default function AuthProvider({ children }: PropsWithChildren) {
-	const [user, setUser] = useUserStorage();
+	const [user, setUser, clearUser] = useUserStorage();
 
 	const setAuthData = async ({ userData }: { userData: User }) => {
 		setUser(userData);
 	};
 
 	const clearAuthData = () => {
-		setUser(null);
+		clearUser();
 	};
 
 	const authContextValue = useMemo(

--- a/packages/user/src/hooks/query/useGetEventDuration.ts
+++ b/packages/user/src/hooks/query/useGetEventDuration.ts
@@ -1,20 +1,14 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import http from 'src/services/api/index.ts';
 import QUERY_KEYS from 'src/services/api/queryKey.ts';
 
-export type EventDuration = { startDate: string; endDate: string };
+export type EventDuration = { startTime: string; endTime: string };
 
 export default function useGetEventDuration() {
 	const { data: duration } = useSuspenseQuery<EventDuration>({
 		queryKey: [QUERY_KEYS.EVENT_DURATION],
-		queryFn: fetchMockData,
+		queryFn: () => http.get('/event-time'),
 	});
 
 	return { duration };
 }
-
-const fetchMockData = (): Promise<EventDuration> =>
-	new Promise((resolve) => {
-		setTimeout(() => {
-			resolve({ startDate: '2024-07-31T15:00:00Z', endDate: '2024-09-10T15:00:00Z' });
-		}, 1000);
-	});

--- a/packages/user/src/hooks/query/useGetFCFSQuiz.ts
+++ b/packages/user/src/hooks/query/useGetFCFSQuiz.ts
@@ -1,4 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import http from 'src/services/api/index.ts';
 import QUERY_KEYS from 'src/services/api/queryKey.ts';
 
 export type FCFSChoice = { num: number; text: string };
@@ -7,36 +8,8 @@ export type FCFSQuiz = { id: number; question: string; choices: FCFSChoice[] };
 export default function useGetFCFSQuiz() {
 	const { data: quiz } = useSuspenseQuery<FCFSQuiz>({
 		queryKey: [QUERY_KEYS.FCFS_QUIZ],
-		queryFn: fetchMockData,
+		queryFn: () => http.get('/quiz'),
 	});
 
 	return { quiz };
 }
-
-const fetchMockData = (): Promise<FCFSQuiz> =>
-	new Promise((resolve) => {
-		setTimeout(() => {
-			resolve({
-				id: 5,
-				question: '질문',
-				choices: [
-					{
-						num: 0,
-						text: '보기1번',
-					},
-					{
-						num: 1,
-						text: '보기2번',
-					},
-					{
-						num: 2,
-						text: '보기3번',
-					},
-					{
-						num: 3,
-						text: '보기4번',
-					},
-				],
-			});
-		}, 1000);
-	});

--- a/packages/user/src/hooks/query/useGetTeamTypeQuiz.ts
+++ b/packages/user/src/hooks/query/useGetTeamTypeQuiz.ts
@@ -1,50 +1,15 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
+import http from 'src/services/api/index.ts';
 import QUERY_KEYS from 'src/services/api/queryKey.ts';
 
-export type Quiz = { id: number; question: string; choices: { text: string }[] };
+export type Quiz = { id: number; question: string; choices: string[] };
 
 export default function useGetTeamTypeQuizzes() {
 	// TODO: 빈 배열 내려올 경우 error handling
 	const { data: quizzes } = useSuspenseQuery<Quiz[]>({
 		queryKey: [QUERY_KEYS.TEAM_TYPE_QUIZ],
-		queryFn: fetchMockData,
+		queryFn: () => http.get('/personality-test-list'),
 	});
+
 	return { quizzes };
 }
-
-const fetchMockData = (): Promise<Quiz[]> =>
-	new Promise((resolve) => {
-		setTimeout(() => {
-			resolve([
-				{
-					id: 1,
-					question: '오늘은 나들이 가는 날!\n나의 드라이브 스타일은?',
-					choices: [
-						{ text: '반려동물과 함께하는 드라이브' },
-						{ text: '음악과 함께하는 혼자만의 드라이브' },
-					],
-				},
-				{
-					id: 2,
-					question: '오랜만에 찾아온 주말,\n나만의 힐링 방법은?',
-					choices: [
-						{ text: '초록초록 자연 속에서 피톤치드 마시기' },
-						{ text: '시원한 에어컨 아래에서 아아 마시기' },
-					],
-				},
-				{
-					id: 3,
-					question: '나의 가방 속 물건은?',
-					choices: [
-						{ text: '가방 따위 필요 없다! 맨손으로 나들이 가기' },
-						{ text: '무엇이든 준비됐어! 바리바리스타' },
-					],
-				},
-				{
-					id: 4,
-					question: '나의 자전거 라이딩 스타일은?',
-					choices: [{ text: '스릴만점! 산악 라이딩' }, { text: '자전거로 여유롭게 공원 한 바퀴!' }],
-				},
-			]);
-		}, 1000);
-	});

--- a/packages/user/src/hooks/query/useSubmitFCFSQuiz.ts
+++ b/packages/user/src/hooks/query/useSubmitFCFSQuiz.ts
@@ -1,25 +1,18 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/naming-convention */
 import { useMutation } from '@tanstack/react-query';
+import http from 'src/services/api/index.ts';
 
 export type SubmitFCFSQuizAnswerRequest = { answer: number };
 
-/** success 는 따로 status 내려주지 않음 */
 export interface SubmitFCFSQuizResponse {
-	status: 'WRONG' | 'END' | 'PARTICIPATED';
+	status: 'WRONG' | 'END' | 'PARTICIPATED' | 'RIGHT';
 }
 
 export default function useSubmitFCFSQuiz() {
 	const mutation = useMutation<SubmitFCFSQuizResponse, Error, SubmitFCFSQuizAnswerRequest>({
-		mutationFn: submitMockData,
+		mutationFn: (data) => http.post('/quiz-user', data),
 	});
 
 	return mutation;
 }
-
-const submitMockData = (): Promise<SubmitFCFSQuizResponse> =>
-	new Promise((resolve) => {
-		setTimeout(() => {
-			resolve({ status: 'END' });
-		}, 2000);
-	});

--- a/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
+++ b/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
@@ -7,7 +7,7 @@ import useAuth from 'src/hooks/useAuth.tsx';
 import http from 'src/services/api/index.ts';
 import type { User } from 'src/types/user.d.ts';
 
-export type SubmitQuizAnswersRequest = { id:number, answer: number }[];
+export type SubmitQuizAnswersRequest = { id: number; answer: number }[];
 
 export interface SubmitQuizAnswersResponse {
 	team: string;
@@ -19,7 +19,7 @@ export default function useSubmitTeamTypeQuizAnswers() {
 	const [_, setToken] = useTokenStorage();
 
 	const mutation = useMutation<SubmitQuizAnswersResponse, Error, SubmitQuizAnswersRequest>({
-		mutationFn: (data: SubmitQuizAnswersRequest) => http.post('/personailty-test', data),
+		mutationFn: (data) => http.post('/personailty-test', data),
 		onSuccess: ({ team, accessToken }) => {
 			const type = team === 'SPACE' ? 'place' : team;
 			const userData = { ...(user as User), type: type.toLowerCase() as Category };

--- a/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
+++ b/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
@@ -19,11 +19,10 @@ export default function useSubmitTeamTypeQuizAnswers() {
 	const [_, setToken] = useTokenStorage();
 
 	const mutation = useMutation<SubmitQuizAnswersResponse, Error, SubmitQuizAnswersRequest>({
-		mutationFn: (data) => http.post('/personailty-test', data),
+		mutationFn: (data) => http.post('/personality-test', data),
 		onSuccess: ({ team, accessToken }) => {
-			const type = team === 'SPACE' ? 'place' : team;
+			const type = team === 'SPACE' ? 'place' : team.toLowerCase();
 			const userData = { ...(user as User), type: type.toLowerCase() as Category };
-
 			setToken(accessToken);
 			setAuthData({ userData });
 		},

--- a/packages/user/src/hooks/socket/index.ts
+++ b/packages/user/src/hooks/socket/index.ts
@@ -10,6 +10,7 @@ export type UseSocketType = {
 };
 export default function useSocket() {
 	const chatSocket = useChatSocket();
+
 	const { onReceiveMessage } = chatSocket;
 
 	const racingSocket = useRacingSocket();
@@ -29,7 +30,7 @@ export default function useSocket() {
 			}
 		});
 		return () => socketClient.disconnect();
-	}, [socketClient]);
+	}, [socketClient, onReceiveMessage, onReceiveStatus]);
 
 	return { chatSocket, racingSocket };
 }

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -1,4 +1,4 @@
-import { RACING_SOCKET_ENDPOINTS } from '@softeer/common/constants';
+import { categoryToSocketCategory, RACING_SOCKET_ENDPOINTS, socketCategoryToCategory } from '@softeer/common/constants';
 import { Category } from '@softeer/common/types';
 import type { SocketSubscribeCallbackType } from '@softeer/common/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -11,23 +11,6 @@ import type {
 	SocketData,
 	VoteStatus,
 } from 'src/types/racing.d.ts';
-
-/**
- * Mapping between Category and SocketCategory
- */
-const categoryToSocketCategory: Record<Category, SocketCategory> = {
-	pet: 'p',
-	travel: 't',
-	place: 's',
-	leisure: 'l',
-};
-
-const socketCategoryToCategory: Record<SocketCategory, Category> = {
-	p: 'pet',
-	t: 'travel',
-	s: 'place',
-	l: 'leisure',
-};
 
 export type UseRacingSocketReturnType = ReturnType<typeof useRacingSocket>;
 
@@ -63,7 +46,7 @@ export default function useRacingSocket() {
 	);
 
 	const handleCarFullyCharged = useCallback((category: Category) => {
-		const chargeData = { [categoryToSocketCategory[category]]: 1 };
+		const chargeData = { [categoryToSocketCategory[category].toLowerCase()]: 1 };
 
 		const completeChargeData = Object.keys(categoryToSocketCategory).reduce(
 			(acc, key) => {
@@ -114,7 +97,7 @@ function hasRankChanged(newRank: RankStatus, currentRank: RankStatus): boolean {
 
 function parseSocketVoteData(data: SocketData): VoteStatus {
 	return Object.entries(data).reduce<VoteStatus>((acc, [socketCategory, value]) => {
-		const category = socketCategoryToCategory[socketCategory as SocketCategory];
+		const category = socketCategoryToCategory[socketCategory.toLowerCase() as SocketCategory];
 		acc[category] = value;
 		return acc;
 	}, {} as VoteStatus);

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -16,17 +16,17 @@ import type {
  * Mapping between Category and SocketCategory
  */
 const categoryToSocketCategory: Record<Category, SocketCategory> = {
-	pet: 'P',
-	travel: 'T',
-	place: 'S',
-	leisure: 'L',
+	pet: 'p',
+	travel: 't',
+	place: 's',
+	leisure: 'l',
 };
 
 const socketCategoryToCategory: Record<SocketCategory, Category> = {
-	P: 'pet',
-	T: 'travel',
-	S: 'place',
-	L: 'leisure',
+	p: 'pet',
+	t: 'travel',
+	s: 'place',
+	l: 'leisure',
 };
 
 export type UseRacingSocketReturnType = ReturnType<typeof useRacingSocket>;

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -50,14 +50,17 @@ export default function useRacingSocket() {
 		}
 	}, [newRankStatus, ranks]);
 
-	const handleStatusChange: SocketSubscribeCallbackType = useCallback((data: unknown) => {
-		const newVoteStatus = parseSocketVoteData(data as SocketData);
-		const isVotesChanged = Object.keys(newVoteStatus).some(
-			(category) => newVoteStatus[category as Category] !== votes[category as Category],
-	);
+	const handleStatusChange: SocketSubscribeCallbackType = useCallback(
+		(data: unknown) => {
+			const newVoteStatus = parseSocketVoteData(data as SocketData);
+			const isVotesChanged = Object.keys(newVoteStatus).some(
+				(category) => newVoteStatus[category as Category] !== votes[category as Category],
+			);
 
-		if (isVotesChanged) setVotes(newVoteStatus);
-	}, [votes]);
+			if (isVotesChanged) setVotes(newVoteStatus);
+		},
+		[votes],
+	);
 
 	const handleCarFullyCharged = useCallback((category: Category) => {
 		const chargeData = { [categoryToSocketCategory[category]]: 1 };

--- a/packages/user/src/hooks/storage/index.ts
+++ b/packages/user/src/hooks/storage/index.ts
@@ -2,10 +2,7 @@ import { Cookie } from '@softeer/common/utils';
 import { useState } from 'react';
 import { toast } from 'src/hooks/useToast.ts';
 
-function useStorage<T>(
-	keyName: string,
-	defaultValue: T,
-): [T, (newValue: T) => void, () => void] {
+function useStorage<T>(keyName: string, defaultValue: T): [T, (newValue: T) => void, () => void] {
 	const [storedValue, setStoredValue] = useState<T>(() => {
 		try {
 			const cookieValue = Cookie.getCookie<T>(keyName);

--- a/packages/user/src/hooks/storage/index.ts
+++ b/packages/user/src/hooks/storage/index.ts
@@ -1,15 +1,12 @@
+import { Cookie } from '@softeer/common/utils';
 import { useState } from 'react';
 import { toast } from 'src/hooks/useToast.ts';
 
 function useStorage<T>(keyName: string, defaultValue: T) {
 	const [storedValue, setStoredValue] = useState(() => {
 		try {
-			const value = localStorage.getItem(keyName);
-			if (value) {
-				return JSON.parse(value);
-			}
-			localStorage.setItem(keyName, JSON.stringify(defaultValue));
-			return defaultValue;
+			const cookieValue = Cookie.getCookie<T>(keyName);
+			return cookieValue !== null ? cookieValue : defaultValue;
 		} catch (err) {
 			return defaultValue;
 		}
@@ -17,14 +14,23 @@ function useStorage<T>(keyName: string, defaultValue: T) {
 
 	const setValue = (newValue: T) => {
 		try {
-			localStorage.setItem(keyName, JSON.stringify(newValue));
+			Cookie.setCookie<T>(keyName, newValue);
+			setStoredValue(newValue);
 		} catch (error) {
-			toast({ description: `${error}` });
+			toast({ description: `${keyName} 저장 실패: ${error}` });
 		}
-		setStoredValue(newValue);
 	};
 
-	return [storedValue, setValue];
+	const clearValue = () => {
+		try {
+			Cookie.clearCookie(keyName);
+			setStoredValue(defaultValue);
+		} catch (error) {
+			toast({ description: `${keyName} 저장 실패: ${error}` });
+		}
+	};
+
+	return [storedValue, setValue, clearValue];
 }
 
 export default useStorage;

--- a/packages/user/src/hooks/storage/index.ts
+++ b/packages/user/src/hooks/storage/index.ts
@@ -2,8 +2,11 @@ import { Cookie } from '@softeer/common/utils';
 import { useState } from 'react';
 import { toast } from 'src/hooks/useToast.ts';
 
-function useStorage<T>(keyName: string, defaultValue: T) {
-	const [storedValue, setStoredValue] = useState(() => {
+function useStorage<T>(
+	keyName: string,
+	defaultValue: T,
+): [T, (newValue: T) => void, () => void] {
+	const [storedValue, setStoredValue] = useState<T>(() => {
 		try {
 			const cookieValue = Cookie.getCookie<T>(keyName);
 			return cookieValue !== null ? cookieValue : defaultValue;

--- a/packages/user/src/hooks/storage/useRacingRankStorage.ts
+++ b/packages/user/src/hooks/storage/useRacingRankStorage.ts
@@ -9,6 +9,6 @@ const INIT_RANK: RankStatus = {
 	leisure: 4,
 };
 
-const useRacingRankStorage = () => useStorage<RankStatus | null>(STORAGE_KEYS.RANK, INIT_RANK);
+const useRacingRankStorage = () => useStorage<RankStatus>(STORAGE_KEYS.RANK, INIT_RANK);
 
 export default useRacingRankStorage;

--- a/packages/user/src/hooks/useToast.ts
+++ b/packages/user/src/hooks/useToast.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 import type { ToastActionElement, ToastProps } from 'src/components/common/toast/Toast.tsx';
 
-const TOAST_LIMIT = 1;
+const TOAST_LIMIT = 5;
 const TOAST_REMOVE_DELAY = 1000000;
 
 type ToasterToast = ToastProps & {

--- a/packages/user/src/types/racing.d.ts
+++ b/packages/user/src/types/racing.d.ts
@@ -3,7 +3,7 @@ import type { Category } from '@softeer/common/types';
 const ranks = [1, 2, 3, 4] as const;
 export type Rank = (typeof ranks)[number];
 
-type SocketCategory = 'P' | 'T' | 'S' | 'L';
+type SocketCategory = 'p' | 't' | 's' | 'l';
 
 export type SocketData = Record<SocketCategory, number>;
 export type VoteStatus = Record<Category, number>;


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지
- 어드민 페이지

  <br/>

## 🔎 작업 내용
> 데모 전까지 목표로 했던 주요 기능 구현 완료!
> 거의 12시간 달린 것 같네요 ㅋㅋ 아 

- user package내부에 local storage로 구현되어있던 storage hook을 cookie 로 교체
- 변경된 socket data type 대응
- api 연동 테스트 완료
_-_ 선착순 퀴즈 데이터 관련 GET, POST API는 오늘 날짜에 해당하는 퀴즈 데이터가 없어서 테스트해보지 못했습니다.
_-_ 모든 케이스를 테스트해본건 아니어서 데모 이후에 다시 확인할 예정
_-_ 데모 전에 error page로 routing되는 global error boundary 추가하면 좋을 것 같습니다

  <br/>