### PR TITLE
[Feature][Task-232] 레이싱 게임을 게임 답게 만들기

### DIFF
--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -1,55 +1,31 @@
 import { Category } from '@softeer/common/types';
-import numeral from 'numeral';
-import { useMemo } from 'react';
+import { PropsWithChildren, memo } from 'react';
 import { TEAM_DESCRIPTIONS } from 'src/constants/teamDescriptions.ts';
 import type { ChargeButtonData } from './ControlButton.tsx';
 
-interface ChargeButtonContentProps extends ChargeButtonData {
+interface ChargeButtonContentProps extends Pick<ChargeButtonData, 'rank'> {
 	type: Category;
 }
 
-export default function ChargeButtonContent({
+const ChargeButtonContent = memo(({
+	children,
 	rank,
-	vote,
 	type,
-	percentage,
-}: ChargeButtonContentProps) {
+}: PropsWithChildren<ChargeButtonContentProps>) => {
 	const { shortTitle, title } = TEAM_DESCRIPTIONS[type];
 	const displayTitle = shortTitle ?? title;
-	const displayVoteStats = useMemo(
-		() => `${percentage.toFixed(1)}% (${formatVoteCount(vote)})`,
-		[percentage, vote],
-	);
 
 	return (
 		<>
 			<h2 className="pt-2">{rank}</h2>
 			<div className="flex flex-col items-center">
-				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{displayVoteStats}</p>
+				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{children}</p>
 				<h6>{displayTitle}</h6>
 			</div>
 		</>
 	);
-}
-
-/** Utility Functions */
-function formatVoteCount(count: number): string {
-	const formatted = numeral(count).format('0,0'); // 기본 포맷팅
-	return convertToKoreanUnit(formatted);
-}
-
-function convertToKoreanUnit(formatted: string): string {
-	const number = parseFloat(formatted.replace(/,/g, ''));
-
-	if (number >= 100000000) {
-		return `${(number / 100000000).toFixed(2)}억`;
-	}
-	if (number >= 10000) {
-		return `${(number / 10000).toFixed(2)}만`;
-	}
-	return formatted;
-}
-
+});
+export default ChargeButtonContent;
 /** Styles */
 const voteStyles: Record<Category, string> = {
 	travel: 'text-orange-500',

--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -7,24 +7,22 @@ interface ChargeButtonContentProps extends Pick<ChargeButtonData, 'rank'> {
 	type: Category;
 }
 
-const ChargeButtonContent = memo(({
-	children,
-	rank,
-	type,
-}: PropsWithChildren<ChargeButtonContentProps>) => {
-	const { shortTitle, title } = TEAM_DESCRIPTIONS[type];
-	const displayTitle = shortTitle ?? title;
+const ChargeButtonContent = memo(
+	({ children, rank, type }: PropsWithChildren<ChargeButtonContentProps>) => {
+		const { shortTitle, title } = TEAM_DESCRIPTIONS[type];
+		const displayTitle = shortTitle ?? title;
 
-	return (
-		<>
-			<h2 className="pt-2">{rank}</h2>
-			<div className="flex flex-col items-center">
-				<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{children}</p>
-				<h6>{displayTitle}</h6>
-			</div>
-		</>
-	);
-});
+		return (
+			<>
+				<h2 className="pt-2">{rank}</h2>
+				<div className="flex flex-col items-center">
+					<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{children}</p>
+					<h6>{displayTitle}</h6>
+				</div>
+			</>
+		);
+	},
+);
 export default ChargeButtonContent;
 /** Styles */
 const voteStyles: Record<Category, string> = {

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -45,7 +45,9 @@ export default function ControlButton({
 		<ControllButtonWrapper rank={rank}>
 			<Gauge percent={progress} />
 			<ChargeButtonWrapper onClick={handleClick} type={type}>
-				<ChargeButtonContent type={type} rank={rank}>{displayVoteStats}</ChargeButtonContent>
+				<ChargeButtonContent type={type} rank={rank}>
+					{displayVoteStats}
+				</ChargeButtonContent>
 			</ChargeButtonWrapper>
 		</ControllButtonWrapper>
 	);

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -1,5 +1,6 @@
 import type { Category } from '@softeer/common/types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import numeral from 'numeral';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useAuth from 'src/hooks/useAuth.tsx';
 import { useToast } from 'src/hooks/useToast.ts';
 import type { Rank } from 'src/types/racing.d.ts';
@@ -28,18 +29,23 @@ export default function ControlButton({
 	type,
 	data,
 }: ControlButtonProps) {
-	const { rank, percentage } = data;
+	const { rank, vote, percentage } = data;
 	const { progress, handleClick } = useGaugeProgress({
 		percentage,
 		onCharge,
 		onFullyCharged,
 	});
 
+	const displayVoteStats = useMemo(
+		() => `${percentage.toFixed(1)}% (${formatVoteCount(vote)})`,
+		[percentage, vote],
+	);
+
 	return (
 		<ControllButtonWrapper rank={rank}>
 			<Gauge percent={progress} />
 			<ChargeButtonWrapper onClick={handleClick} type={type}>
-				<ChargeButtonContent type={type} {...data} />
+				<ChargeButtonContent type={type} rank={rank}>{displayVoteStats}</ChargeButtonContent>
 			</ChargeButtonWrapper>
 		</ControllButtonWrapper>
 	);
@@ -78,4 +84,22 @@ function useGaugeProgress({
 	}, [onCharge, onFullyCharged, isAuthenticated, percentage, toast]);
 
 	return { progress, handleClick };
+}
+
+/** Utility Functions */
+function formatVoteCount(count: number): string {
+	const formatted = numeral(count).format('0,0'); // 기본 포맷팅
+	return convertToKoreanUnit(formatted);
+}
+
+function convertToKoreanUnit(formatted: string): string {
+	const number = parseFloat(formatted.replace(/,/g, ''));
+
+	if (number >= 100000000) {
+		return `${(number / 100000000).toFixed(2)}억`;
+	}
+	if (number >= 10000) {
+		return `${(number / 10000).toFixed(2)}만`;
+	}
+	return formatted;
 }

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import Lightning from 'src/assets/icons/lighting.svg?react';
 
 interface GaugeProps {
 	percent: number;
 }
-export default function Gauge({ percent }: GaugeProps) {
+const Gauge = memo(({ percent }: GaugeProps) => {
 	const backgroundColor = useMemo(() => {
 		if (percent < 22) return 'bg-gradient-gauge1';
 		if (percent < 57) return 'bg-gradient-gauge2';
@@ -23,4 +23,6 @@ export default function Gauge({ percent }: GaugeProps) {
 			</div>
 		</div>
 	);
-}
+});
+
+export default Gauge;

--- a/packages/user/src/components/event/racing/dashboard/Casper.tsx
+++ b/packages/user/src/components/event/racing/dashboard/Casper.tsx
@@ -1,4 +1,5 @@
 import type { Category } from '@softeer/common/types';
+import { memo } from 'react';
 import MarkerIcon from 'src/assets/icons/car-marker.svg?react';
 import useAuth from 'src/hooks/useAuth.tsx';
 import type { Rank } from 'src/types/racing.d.ts';
@@ -8,7 +9,8 @@ interface CasperProps {
 	rank: Rank;
 	className: string;
 }
-export default function Casper({ type, rank, className }: CasperProps) {
+
+const Casper = memo(({ type, rank, className }: CasperProps) => {
 	const { user } = useAuth();
 	const isMyCasper = user?.type === type;
 
@@ -20,7 +22,8 @@ export default function Casper({ type, rank, className }: CasperProps) {
 			<img src={imageUrls[type]} alt={`${rank}등 차`} className="object-contain" />
 		</div>
 	);
-}
+});
+export default Casper;
 
 const transitionStyles = 'transform transition-all duration-700 ease-in-out';
 

--- a/packages/user/src/components/event/racing/dashboard/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { CATEGORIES } from '@softeer/common/constants';
 import type { Category } from '@softeer/common/types';
-import { Suspense } from 'react';
+import { Suspense, memo } from 'react';
 import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import Background from './Background.tsx';
 import RacingCard from './card/index.tsx';
@@ -12,8 +12,7 @@ interface RacingDashboardProps extends Pick<UseRacingSocketReturnType, 'ranks'> 
 	chargedCar: Category | null;
 }
 
-export default function RacingDashboard({ ranks, chargedCar }: RacingDashboardProps) {
-	return (
+const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
 		<div className="relative h-[685px] w-full">
 			<HeaderSection />
 			<RacingCardSection />
@@ -27,24 +26,22 @@ export default function RacingDashboard({ ranks, chargedCar }: RacingDashboardPr
 			))}
 			<Background />
 		</div>
-	);
-}
+	));
 
-function HeaderSection() {
-	return (
+export default RacingDashboard;
+
+const HeaderSection = memo(() => (
 		<div className="absolute -top-[5px] flex w-full flex-col items-center">
 			<RacingTitle />
 			<Suspense>
 				<EventTimer />
 			</Suspense>
 		</div>
-	);
-}
+	));
 
-function RacingCardSection() {
-	return (
+const RacingCardSection = memo(() => (
 		<div className="absolute left-[27px] top-[95px]">
 			<RacingCard />
 		</div>
-	);
-}
+	),
+);

--- a/packages/user/src/components/event/racing/dashboard/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/index.tsx
@@ -13,35 +13,34 @@ interface RacingDashboardProps extends Pick<UseRacingSocketReturnType, 'ranks'> 
 }
 
 const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
-		<div className="relative h-[685px] w-full">
-			<HeaderSection />
-			<RacingCardSection />
-			{CATEGORIES.map((type) => (
-				<Casper
-					key={type}
-					type={type}
-					rank={ranks[type]}
-					className={chargedCar === type ? 'scale-110' : ''}
-				/>
-			))}
-			<Background />
-		</div>
-	));
+	<div className="relative h-[685px] w-full">
+		<HeaderSection />
+		<RacingCardSection />
+		{CATEGORIES.map((type) => (
+			<Casper
+				key={type}
+				type={type}
+				rank={ranks[type]}
+				className={chargedCar === type ? 'scale-110' : ''}
+			/>
+		))}
+		<Background />
+	</div>
+));
 
 export default RacingDashboard;
 
 const HeaderSection = memo(() => (
-		<div className="absolute -top-[5px] flex w-full flex-col items-center">
-			<RacingTitle />
-			<Suspense>
-				<EventTimer />
-			</Suspense>
-		</div>
-	));
+	<div className="absolute -top-[5px] flex w-full flex-col items-center">
+		<RacingTitle />
+		<Suspense>
+			<EventTimer />
+		</Suspense>
+	</div>
+));
 
 const RacingCardSection = memo(() => (
-		<div className="absolute left-[27px] top-[95px]">
-			<RacingCard />
-		</div>
-	),
-);
+	<div className="absolute left-[27px] top-[95px]">
+		<RacingCard />
+	</div>
+));

--- a/packages/user/src/components/layout/header/auth/LogoutButton.tsx
+++ b/packages/user/src/components/layout/header/auth/LogoutButton.tsx
@@ -6,22 +6,28 @@ const LOGOUT_SUCCESS_TOAST_DECRIPTION = '로그아웃 완료! 꼭 다시 돌아�
 const TOAST_DISPLAY_SECOND = 1000;
 
 export default function LogoutButton() {
-  const { toast } = useToast();
-  const { user, clearAuthData } = useAuth();
-  const name = user?.name ?? '캐스퍼';
+	const { toast } = useToast();
+	const { user, clearAuthData } = useAuth();
+	const name = user?.name ?? '캐스퍼';
 
-  const logout = useCallback(() => {
-    toast({ description: LOGOUT_SUCCESS_TOAST_DECRIPTION });
-    setTimeout(() => clearAuthData(), TOAST_DISPLAY_SECOND);
-    }, [toast]);
+	const logout = useCallback(() => {
+		toast({ description: LOGOUT_SUCCESS_TOAST_DECRIPTION });
+		setTimeout(() => clearAuthData(), TOAST_DISPLAY_SECOND);
+	}, [toast]);
 
-  return (
-    <div className="flex items-center gap-4">
-      <p className="text-detail-1 font-medium"><strong>{name}</strong>님 반갑습니다</p>
-      <span>|</span>
-      <button type="button" onClick={logout} className="flex items-center justify-center gap-3 rounded-1 px-2 py-1 bg-neutral-800">
-        <p className="text-detail-2">로그아웃</p>
-      </button>
-    </div>
-  );
+	return (
+		<div className="flex items-center gap-4">
+			<p className="text-detail-1 font-medium">
+				<strong>{name}</strong>님 반갑습니다
+			</p>
+			<span>|</span>
+			<button
+				type="button"
+				onClick={logout}
+				className="rounded-1 flex items-center justify-center gap-3 bg-neutral-800 px-2 py-1"
+			>
+				<p className="text-detail-2">로그아웃</p>
+			</button>
+		</div>
+	);
 }

--- a/packages/user/src/components/layout/header/auth/index.tsx
+++ b/packages/user/src/components/layout/header/auth/index.tsx
@@ -10,8 +10,10 @@ export default function AuthButton() {
 }
 
 function UnauthButton() {
-	return <div className="flex items-center gap-2">
-	<SpeechBubble />
-	<UserIcon />
-        </div>;
+	return (
+		<div className="flex items-center gap-2">
+			<SpeechBubble />
+			<UserIcon />
+		</div>
+	);
 }

--- a/packages/user/src/components/shared/modal/login/LoginStep.tsx
+++ b/packages/user/src/components/shared/modal/login/LoginStep.tsx
@@ -17,7 +17,11 @@ export default function LoginStep() {
 				<strong>로그인</strong>을 진행해주세요
 			</p>
 			<button type="submit" onClick={handleSubmit}>
-				<img alt="카카오 로그인" src="/images/kakao-login.png" className="w-full object-contain hover:cursor-pointer" />
+				<img
+					alt="카카오 로그인"
+					src="/images/kakao-login.png"
+					className="w-full object-contain hover:cursor-pointer"
+				/>
 			</button>
 		</div>
 	);

--- a/packages/user/src/constants/environments.ts
+++ b/packages/user/src/constants/environments.ts
@@ -2,7 +2,5 @@
 //* * Environment Variables             */
 //* *********************************** */
 
-export const {
-	VITE_BASE_URL: API_BASE_URL,
-	VITE_SOCKET_BASE_URL: SOCKET_BASE_URL,
-} = import.meta.env;
+export const { VITE_BASE_URL: API_BASE_URL, VITE_SOCKET_BASE_URL: SOCKET_BASE_URL } = import.meta
+	.env;

--- a/packages/user/src/context/auth/AuthContext.ts
+++ b/packages/user/src/context/auth/AuthContext.ts
@@ -4,7 +4,7 @@ import type { User } from 'src/types/user.d.ts';
 interface AuthContextType {
 	isAuthenticated: boolean;
 	user: User | null;
-	setAuthData: ({ userData, accessToken }: { userData: User;accessToken:string }) => void
+	setAuthData: ({ userData, accessToken }: { userData: User; accessToken: string }) => void;
 	clearAuthData: () => void;
 }
 

--- a/packages/user/src/context/auth/index.tsx
+++ b/packages/user/src/context/auth/index.tsx
@@ -6,13 +6,15 @@ import type { User } from 'src/types/user.d.ts';
 
 export default function AuthProvider({ children }: PropsWithChildren) {
 	const [user, setUser, clearUser] = useUserStorage();
-	const [,setToken, clearToken] = useTokenStorage();
+	const [, setToken, clearToken] = useTokenStorage();
 
 	const setAuthData = useCallback(
-		({ userData, accessToken }: { userData: User ;accessToken:string }) => {
-		setUser(userData);
-		setToken(accessToken);
-	}, [setUser, setToken]);
+		({ userData, accessToken }: { userData: User; accessToken: string }) => {
+			setUser(userData);
+			setToken(accessToken);
+		},
+		[setUser, setToken],
+	);
 
 	const clearAuthData = useCallback(() => {
 		clearUser();
@@ -20,13 +22,15 @@ export default function AuthProvider({ children }: PropsWithChildren) {
 		window.location.reload();
 	}, [clearUser, clearToken]);
 
-	const authContext = useMemo(() => ({
-		isAuthenticated: Boolean(user),
-		user,
-		setAuthData,
-		clearAuthData,
-	}), [user]);
+	const authContext = useMemo(
+		() => ({
+			isAuthenticated: Boolean(user),
+			user,
+			setAuthData,
+			clearAuthData,
+		}),
+		[user],
+	);
 
-	return <AuthContext.Provider value={authContext}>{children}
-        </AuthContext.Provider>;
+	return <AuthContext.Provider value={authContext}>{children}</AuthContext.Provider>;
 }

--- a/packages/user/src/pages/KakaoRedirectPage.tsx
+++ b/packages/user/src/pages/KakaoRedirectPage.tsx
@@ -5,22 +5,22 @@ import useAuth from 'src/hooks/useAuth.tsx';
 import CustomError from 'src/utils/error.ts';
 
 export default function KakaoRedirectPage() {
-  const { setAuthData } = useAuth();
-  const [searchParams] = useSearchParams();
+	const { setAuthData } = useAuth();
+	const [searchParams] = useSearchParams();
 
-  const accessToken = searchParams.get('accessToken');
-  const userId = searchParams.get('userId');
-  const userName = searchParams.get('userName') ?? '캐스퍼';
+	const accessToken = searchParams.get('accessToken');
+	const userId = searchParams.get('userId');
+	const userName = searchParams.get('userName') ?? '캐스퍼';
 
-  useEffect(() => {
-    if (!accessToken || !userId) {
-      throw new CustomError('정상적으로 유저 정보가 전달되지 않았습니다.', 400);
-    }
+	useEffect(() => {
+		if (!accessToken || !userId) {
+			throw new CustomError('정상적으로 유저 정보가 전달되지 않았습니다.', 400);
+		}
 
-    setAuthData({ userData: { id: userId, name: userName }, accessToken });
-    window.history.replaceState(null, '', RoutePaths.Home);
-    window.history.go(-1);
-  }, [accessToken, userId, userName, setAuthData]);
+		setAuthData({ userData: { id: userId, name: userName }, accessToken });
+		window.history.replaceState(null, '', RoutePaths.Home);
+		window.history.go(-1);
+	}, [accessToken, userId, userName, setAuthData]);
 
-  return null;
+	return null;
 }

--- a/packages/user/src/utils/error.ts
+++ b/packages/user/src/utils/error.ts
@@ -1,10 +1,10 @@
 // utils/customError.ts
 export default class CustomError extends Error {
-  status: number;
+	status: number;
 
-  constructor(message: string, status: number) {
-    super(message);
-    this.status = status;
-    this.name = this.constructor.name;
-  }
+	constructor(message: string, status: number) {
+		super(message);
+		this.status = status;
+		this.name = this.constructor.name;
+	}
 }


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지
- 어드민 페이지

  <br/>

## 🔎 작업 내용
> 내일 @jun-ha 님과 레이싱 인터렉션 맞춰보기로 했습니다
> 밀도 있는 모각코를 위해 논의했던 부분 일차적으로 구현

### as-is
`MAX_COUNT` 번 클릭할 경우 gauge가 100%가 되면서 서버에 카운트 수 +1 전송
`DISABLED_TIME` 동안 해당 캐스퍼에 한하여 클릭 비활성화 뒤 재시도 가능하도록 제한

### to-be
지연 시간은 제거 
클릭 한 번 당 서버 +1 
_-_ count 값을 모아서 서버에 보내는 건 서버와 싱크도 고려해야 합니다 내일 논의해보죠


  <br/>
