### PR TITLE
[Feature][Task-241] 로그인 시 socket 연결 해제 후 다시 연결

### DIFF
--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -6,7 +6,9 @@ import ChatInputArea from './inputArea/index.tsx';
 
 /** 실시간 기대평 섹션 */
 
-function RealTimeChatting({ chatSocket: { onSendMessage, messages } }: Pick<UseSocketReturnType, 'chatSocket'>) {
+function RealTimeChatting({
+	chatSocket: { onSendMessage, messages },
+}: Pick<UseSocketReturnType, 'chatSocket'>) {
 	return (
 		<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
 			<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>

--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -1,12 +1,12 @@
 import { ChatList } from '@softeer/common/components';
 import ChatInput from 'src/components/event/chatting/inputArea/input/index.tsx';
-import { UseChatSocketReturnType } from 'src/hooks/socket/useChatSocket.ts';
+import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
 import Chat from './Chat.tsx';
 import ChatInputArea from './inputArea/index.tsx';
 
 /** 실시간 기대평 섹션 */
 
-function RealTimeChatting({ onSendMessage, messages }: UseChatSocketReturnType) {
+function RealTimeChatting({ chatSocket: { onSendMessage, messages } }: Pick<UseSocketReturnType, 'chatSocket'>) {
 	return (
 		<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
 			<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -1,12 +1,12 @@
 import { Category } from '@softeer/common/types';
 import { useState } from 'react';
 import SECTION_ID from 'src/constants/sectionId.ts';
-import { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
+import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
 import RacingControls from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
-export default function RealTimeRacing(racingSocket: UseRacingSocketReturnType) {
+export default function RealTimeRacing({ racingSocket }: Pick<UseSocketReturnType, 'racingSocket'>) {
 	const [chargedCar, setChargedCar] = useState<Category | null>(null);
 
 	const { ranks, votes, onCarFullyCharged } = racingSocket;

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -6,7 +6,9 @@ import RacingControls from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
-export default function RealTimeRacing({ racingSocket }: Pick<UseSocketReturnType, 'racingSocket'>) {
+export default function RealTimeRacing({
+	racingSocket,
+}: Pick<UseSocketReturnType, 'racingSocket'>) {
 	const [chargedCar, setChargedCar] = useState<Category | null>(null);
 
 	const { ranks, votes, onCarFullyCharged } = racingSocket;

--- a/packages/user/src/components/layout/ErrorContainer.tsx
+++ b/packages/user/src/components/layout/ErrorContainer.tsx
@@ -14,6 +14,7 @@ export default function ErrorContainer({ errorMessage, reset }: ErrorFallbackPro
 			<img src="/images/fcfs/result/wrong.png" alt="오류 발생 이미지" />
 			<div className="flex flex-col items-center gap-5">
 				<h4>{errorMessage}</h4>
+				<p>문제가 계속된다면 관리자에게 문의해주세요</p>
 				<Button onClick={reset}>홈으로 돌아가기</Button>
 			</div>
 		</div>

--- a/packages/user/src/context/auth/index.tsx
+++ b/packages/user/src/context/auth/index.tsx
@@ -6,7 +6,7 @@ import type { User } from 'src/types/user.d.ts';
 
 export default function AuthProvider({ children }: PropsWithChildren) {
 	const [user, setUser, clearUser] = useUserStorage();
-	const [, setToken, clearToken] = useTokenStorage();
+	const [token, setToken, clearToken] = useTokenStorage();
 
 	const setAuthData = useCallback(
 		({ userData, accessToken }: { userData: User; accessToken: string }) => {
@@ -24,7 +24,7 @@ export default function AuthProvider({ children }: PropsWithChildren) {
 
 	const authContext = useMemo(
 		() => ({
-			isAuthenticated: Boolean(user),
+			isAuthenticated: Boolean(token),
 			user,
 			setAuthData,
 			clearAuthData,

--- a/packages/user/src/hooks/socket/index.ts
+++ b/packages/user/src/hooks/socket/index.ts
@@ -1,35 +1,38 @@
 import { CHAT_SOCKET_ENDPOINTS, RACING_SOCKET_ENDPOINTS } from '@softeer/common/constants';
 import { useEffect } from 'react';
 import socketClient from 'src/services/socket.ts';
-import useChatSocket, { UseChatSocketReturnType } from './useChatSocket.ts';
-import useRacingSocket, { UseRacingSocketReturnType } from './useRacingSocket.ts';
+import CustomError from 'src/utils/error.ts';
+import useChatSocket from './useChatSocket.ts';
+import useRacingSocket from './useRacingSocket.ts';
 
-export type UseSocketType = {
-	chatSocket: UseChatSocketReturnType;
-	racingSocket: UseRacingSocketReturnType;
-};
+export type UseSocketReturnType = ReturnType<typeof useSocket>;
+
 export default function useSocket() {
 	const chatSocket = useChatSocket();
 
-	const { onReceiveMessage } = chatSocket;
+	const { onReceiveMessage, ...chatSocketProps } = chatSocket;
 
 	const racingSocket = useRacingSocket();
-	const { onReceiveStatus } = racingSocket;
+	const { onReceiveStatus, ...racingSocketProps } = racingSocket;
 
 	useEffect(() => {
-		socketClient.connect((isConnected) => {
-			if (isConnected) {
-				socketClient.subscribe({
-					destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE,
-					callback: onReceiveMessage,
-				});
-				socketClient.subscribe({
-					destination: RACING_SOCKET_ENDPOINTS.SUBSCRIBE,
-					callback: onReceiveStatus,
-				});
-			}
-		});
+		if (!socketClient.isConnected) {
+			socketClient.connect((isSuccess) => {
+				if (isSuccess) {
+					socketClient.subscribe({
+						destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE,
+						callback: onReceiveMessage,
+					});
+					socketClient.subscribe({
+						destination: RACING_SOCKET_ENDPOINTS.SUBSCRIBE,
+						callback: onReceiveStatus,
+					});
+				} else {
+					throw new CustomError('서버에서 데이터를 불러오는 데 실패했습니다.', 500);
+				}
+			});
+		}
 	}, [socketClient, onReceiveMessage, onReceiveStatus]);
 
-	return { chatSocket, racingSocket };
+	return { chatSocket: chatSocketProps, racingSocket: racingSocketProps };
 }

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -8,9 +8,7 @@ import type { SocketSubscribeCallbackType } from '@softeer/common/utils';
 import { useCallback, useMemo, useState } from 'react';
 import useRacingVoteStorage from 'src/hooks/storage/useRacingVoteStorage.ts';
 import socketClient from 'src/services/socket.ts';
-import type {
-	Rank, SocketCategory, VoteStatus,
-} from 'src/types/racing.d.ts';
+import type { Rank, SocketCategory, VoteStatus } from 'src/types/racing.d.ts';
 
 export type UseRacingSocketReturnType = ReturnType<typeof useRacingSocket>;
 type RankStatus = Record<Category, Rank>;

--- a/packages/user/src/hooks/socket/useSocketHandlers.ts
+++ b/packages/user/src/hooks/socket/useSocketHandlers.ts
@@ -1,0 +1,12 @@
+import useChatSocket from './useChatSocket.ts';
+import useRacingSocket from './useRacingSocket.ts';
+
+export default function useSocketHandlers() {
+	const chatSocket = useChatSocket();
+	const racingSocket = useRacingSocket();
+
+	return {
+		onReceiveMessage: chatSocket.onReceiveMessage,
+		onReceiveStatus: racingSocket.onReceiveStatus,
+	};
+}

--- a/packages/user/src/pages/ErrorPage.tsx
+++ b/packages/user/src/pages/ErrorPage.tsx
@@ -9,8 +9,9 @@ export default function ErrorPage({ message = '문제가 발생했어요!' }: { 
 	const navigate = useNavigate();
 
 	return (
-	<ErrorContainer
-		errorMessage={error?.message ?? message}
+		<ErrorContainer
+			errorMessage={error?.message ?? message}
 			reset={() => navigate(RoutePaths.Home)}
-	/>);
+		/>
+	);
 }

--- a/packages/user/src/pages/EventPage.tsx
+++ b/packages/user/src/pages/EventPage.tsx
@@ -13,8 +13,8 @@ export default function EventPage() {
 
 	return (
 		<>
-			<RealTimeRacing {...racingSocket} />
-			<RealTimeChatting {...chatSocket} />
+			<RealTimeRacing racingSocket={racingSocket} />
+			<RealTimeChatting chatSocket={chatSocket} />
 		</>
 	);
 }

--- a/packages/user/src/pages/KakaoRedirectPage.tsx
+++ b/packages/user/src/pages/KakaoRedirectPage.tsx
@@ -1,11 +1,16 @@
+import { CHAT_SOCKET_ENDPOINTS, RACING_SOCKET_ENDPOINTS } from '@softeer/common/constants';
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import RoutePaths from 'src/constants/routePath.ts';
+import useSocketHandlers from 'src/hooks/socket/useSocketHandlers.ts';
 import useAuth from 'src/hooks/useAuth.tsx';
+import socketClient from 'src/services/socket.ts';
 import CustomError from 'src/utils/error.ts';
 
 export default function KakaoRedirectPage() {
+	const { onReceiveMessage, onReceiveStatus } = useSocketHandlers();
 	const { setAuthData } = useAuth();
+
 	const [searchParams] = useSearchParams();
 
 	const accessToken = searchParams.get('accessToken');
@@ -18,6 +23,24 @@ export default function KakaoRedirectPage() {
 		}
 
 		setAuthData({ userData: { id: userId, name: userName }, accessToken });
+
+		if (socketClient.isConnected) {
+			socketClient.reconnect((isSuccess) => {
+				if (isSuccess) {
+					socketClient.subscribe({
+						destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE,
+						callback: onReceiveMessage,
+					});
+					socketClient.subscribe({
+						destination: RACING_SOCKET_ENDPOINTS.SUBSCRIBE,
+						callback: onReceiveStatus,
+					});
+				} else {
+					throw new CustomError('서버에서 데이터를 불러오는 데 실패했습니다.', 500);
+				}
+			});
+		}
+
 		window.history.replaceState(null, '', RoutePaths.Home);
 		window.history.go(-1);
 	}, [accessToken, userId, userName, setAuthData]);

--- a/packages/user/src/pages/KakaoRedirectPage.tsx
+++ b/packages/user/src/pages/KakaoRedirectPage.tsx
@@ -1,15 +1,14 @@
-import { CHAT_SOCKET_ENDPOINTS, RACING_SOCKET_ENDPOINTS } from '@softeer/common/constants';
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import RoutePaths from 'src/constants/routePath.ts';
-import useSocketHandlers from 'src/hooks/socket/useSocketHandlers.ts';
-import useAuth from 'src/hooks/useAuth.tsx';
-import socketClient from 'src/services/socket.ts';
+import useTokenStorage from 'src/hooks/storage/useTokenStorage.ts';
+import useUserStorage from 'src/hooks/storage/useUserStorage.ts';
 import CustomError from 'src/utils/error.ts';
 
 export default function KakaoRedirectPage() {
-	const { onReceiveMessage, onReceiveStatus } = useSocketHandlers();
-	const { setAuthData } = useAuth();
+	const [, setUser] = useUserStorage();
+	const [, setToken] = useTokenStorage();
+	const navigate = useNavigate();
 
 	const [searchParams] = useSearchParams();
 
@@ -21,29 +20,11 @@ export default function KakaoRedirectPage() {
 		if (!accessToken || !userId) {
 			throw new CustomError('로그인 동작 중 정상적으로 유저 정보가 전달되지 않았습니다.', 400);
 		}
+		setUser({ id: userId, name: userName });
+		setToken(accessToken);
 
-		setAuthData({ userData: { id: userId, name: userName }, accessToken });
-
-		if (socketClient.isConnected) {
-			socketClient.reconnect((isSuccess) => {
-				if (isSuccess) {
-					socketClient.subscribe({
-						destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE,
-						callback: onReceiveMessage,
-					});
-					socketClient.subscribe({
-						destination: RACING_SOCKET_ENDPOINTS.SUBSCRIBE,
-						callback: onReceiveStatus,
-					});
-				} else {
-					throw new CustomError('서버에서 데이터를 불러오는 데 실패했습니다.', 500);
-				}
-			});
-		}
-
-		window.history.replaceState(null, '', RoutePaths.Home);
-		window.history.go(-1);
-	}, [accessToken, userId, userName, setAuthData]);
+		navigate(RoutePaths.Event, { replace: true });
+	}, [accessToken, userId, userName]);
 
 	return null;
 }

--- a/packages/user/src/routes/router.tsx
+++ b/packages/user/src/routes/router.tsx
@@ -26,12 +26,9 @@ const routes: RouteObject[] = [
 				path: RoutePaths.Event,
 				element: <EventPage />,
 			},
-			{
-				path: RoutePaths.KakaoOauthRedirect,
-				element: <KakaoRedirectPage />,
-			},
 		],
 	},
+	{ path: RoutePaths.KakaoOauthRedirect, element: <KakaoRedirectPage /> },
 	{ path: '*', element: <NotFoundErrorPage /> },
 ];
 


### PR DESCRIPTION
## 🔘Part

- 공통 패키지
- 이벤트 페이지

  <br/>

## 🔎 작업 내용

`window.location.href`, `window.history.go` 등의 method를 사용해 페이지 redirect 할 경우 maximum rerender 발생하는 것으로 확인
- navigate hook을 사용하지 않은 이유는 다음과 같습니다
_-_ navigate로는 직전 페이지를 직접적으로 알아낼 수 있는 방법이 없는 것으로 알고 있어서 어디로 라우팅해줄 지 고민하다가 go(-1)를 사용하기로 함
_-_ kakao redirect page가 auth context provider 로직 아래에 위치
_->_ react-router-dom navigate hook 사용해 router 이동할 경우, outlet 의 부모 컴포넌트?라고 해야하나요 layout 에 위치한 컴포넌트는 리렌더링 되지 않음
_->_ 로그인 해도 `auth button`(`useAuth` context 를 사용하는 header component)이 리렌더링 되지 않아 새로고침 이전까지 로그인 이전 버튼이 그대로 노출되는 문제 

socket 연동해주는 이벤트 페이지로 자동 라우팅 되도록 하는 로직으로 변경했습니다. 
- 로그인 완료 시 명시적으로 socket을 reconnect하는 로직을 구현 시도
- 연결되어있지 않은 유저의 경우 아무 동작도 하지 않도록 하는 로직을 추가했었다가 socket 연결 로직이 이곳 저곳 분산되는 것도 별로인 것 같아서 이벤트 페이지 라우팅을 선택했습니다
- 기획 상으로도 로그인 이후 이벤트 참여 페이지로 이동하는 플로우가 자연스럽다고 판단했습니다.

socket client 연결 중 stomp error 발생 시 throw 500 custom error
- 연결 및 구독 이후 발생한 에러 처리는 @jun-ha 님 의견에 따라 optional task로 우선순위 낮추기로 결정
_-_ 서버에서 error topic으로 에러를 전달하는 로직은 이미 구현되어 있고 fe만 작업하면 됨
- 만약 지금 상황에서 연결 이후 소켓 관련 에러가 발생하더라도 global error boundary 로 catch 가능
  <br/>