### PR TITLE
[Feature][Task-259] 공유 링크 생성 api method GET으로 수정해 구현

### DIFF
--- a/packages/user/src/components/event/racing/dashboard/card/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/index.tsx
@@ -13,13 +13,13 @@ const ProtectedTeamSelectModal = memo(withAuth<TeamSelectModalProps>(TeamSelectM
 
 export default function RacingCard() {
 	const { user } = useAuth();
-	const [type, setType] = useState<Category | undefined>(user?.type);
+	const [type, setType] = useState<Category | null | undefined>(user?.type);
 
 	return (
 		<div className="bg-foreground/10 flex flex-col items-center rounded-[5px] p-4 pt-2 backdrop-blur-sm">
 			<CardTitle name={user?.name} />
-			{type ? (
-				<ShareCountTeamCard type={type} encryptedUserId={user?.encryptedUserId} size="racing" />
+			{type && user?.encryptedUserId ? (
+				<ShareCountTeamCard type={type} encryptedUserId={user.encryptedUserId} size="racing" />
 			) : (
 				<ProtectedTeamSelectModal
 					openTrigger={

--- a/packages/user/src/components/layout/index.tsx
+++ b/packages/user/src/components/layout/index.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom';
+import PendingContainer from 'src/components/common/PendingContainer.tsx';
 import useInitialize from 'src/hooks/useInitialize.ts';
 import Banner from './banner/index.tsx';
 import BodyContainer from './BodyContainer.tsx';
@@ -8,7 +9,11 @@ import Header from './header/index.tsx';
 import TopSectionContainer from './TopSectionContainer.tsx';
 
 export default function Layout() {
-	useInitialize();
+	const { user, newUser, isFetching } = useInitialize();
+
+	if (isFetching || user?.encryptedUserId !== newUser?.encryptedUserId) {
+		return <PendingContainer message="사용자 정보를 불러오고 있습니다!" />;
+	}
 
 	return (
 		<div className="relative flex h-screen min-w-max flex-col overflow-hidden">

--- a/packages/user/src/components/shared/ShareCountTeamCard.tsx
+++ b/packages/user/src/components/shared/ShareCountTeamCard.tsx
@@ -9,7 +9,7 @@ import TeamCardTemplate from './teamCardTemplate/index.tsx';
 
 type ShareCountTeamCardProps = {
 	type: Category;
-	encryptedUserId: string | undefined;
+	encryptedUserId: string;
 	size: 'racing' | 'modal';
 };
 export default function ShareCountTeamCard({

--- a/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
@@ -18,7 +18,11 @@ export default function ResultStep() {
 
 	return (
 		<div className="grid h-full items-center gap-11 p-8 sm:p-12 md:grid-flow-col lg:p-16">
-			<ShareCountTeamCard type={type} size="modal" encryptedUserId={user?.encryptedUserId} />
+			<ShareCountTeamCard
+				type={type}
+				size="modal"
+				encryptedUserId={user?.encryptedUserId as string}
+			/>
 			<div className="flex h-full max-w-lg flex-col justify-between gap-10 pb-12 pt-5 sm:max-w-xl md:max-h-[400px] md:pb-2">
 				<div>
 					<p className={`${titleStyles} text-heading-8 mb-6 whitespace-pre-line font-bold`}>

--- a/packages/user/src/components/shared/withAuthHOC.tsx
+++ b/packages/user/src/components/shared/withAuthHOC.tsx
@@ -15,10 +15,7 @@ export default function withAuth<T extends object>(WrappedComponent: React.Compo
 		const { isAuthenticated } = useAuth();
 		const [isUnauthenticatedDisplay, setIsUnauthenticatedDisplay] = useState(false);
 
-		const handleLoginModalClose = useCallback(() => {
-			setIsUnauthenticatedDisplay(false);
-			window.location.reload();
-		}, []);
+		const handleLoginModalClose = useCallback(() => setIsUnauthenticatedDisplay(false), []);
 
 		if (!isAuthenticated || isUnauthenticatedDisplay) {
 			if (!isUnauthenticatedDisplay) setIsUnauthenticatedDisplay(true);

--- a/packages/user/src/hooks/query/useGetLinkShareCount.ts
+++ b/packages/user/src/hooks/query/useGetLinkShareCount.ts
@@ -6,7 +6,7 @@ export type LinkShareCount = { clickNumber: number };
 
 export default function useGetLinkShareCount() {
 	const { data: linkShareCount } = useSuspenseQuery<LinkShareCount>({
-		queryKey: [QUERY_KEYS.LINK_SHARE_COUNT],
+		queryKey: [QUERY_KEYS.GET_LINK_SHARE_COUNT],
 		queryFn: () => http.get('/click-number'),
 	});
 

--- a/packages/user/src/hooks/query/useGetUserInfo.ts
+++ b/packages/user/src/hooks/query/useGetUserInfo.ts
@@ -16,7 +16,11 @@ export type UserResponse = {
 export default function useGetUserInfo() {
 	const { isAuthenticated, token } = useAuth();
 
-	const { data: userInfo, status } = useQuery<UserResponse>({
+	const {
+		data: userInfo,
+		status,
+		...props
+	} = useQuery<UserResponse>({
 		queryKey: [QUERY_KEYS.USER_INFO, token],
 		queryFn: () => http.get('/user-info'),
 		enabled: isAuthenticated,
@@ -28,5 +32,5 @@ export default function useGetUserInfo() {
 		}
 	}, [status]);
 
-	return { userInfo };
+	return { userInfo, ...props };
 }

--- a/packages/user/src/hooks/query/useGetUserInfo.ts
+++ b/packages/user/src/hooks/query/useGetUserInfo.ts
@@ -14,10 +14,10 @@ export type UserResponse = {
 };
 
 export default function useGetUserInfo() {
-	const { isAuthenticated } = useAuth();
+	const { isAuthenticated, token } = useAuth();
 
 	const { data: userInfo, status } = useQuery<UserResponse>({
-		queryKey: [QUERY_KEYS.USER_INFO],
+		queryKey: [QUERY_KEYS.USER_INFO, token],
 		queryFn: () => http.get('/user-info'),
 		enabled: isAuthenticated,
 	});

--- a/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
+++ b/packages/user/src/hooks/query/useSubmitTeamTypeQuizAnswers.ts
@@ -1,11 +1,9 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { ServerCategoryEnum } from '@softeer/common/types';
 import { useMutation } from '@tanstack/react-query';
-import serverTeamEnumToClient from 'src/constants/serverMapping.ts';
 import useAuth from 'src/hooks/useAuth.ts';
+import { queryClient } from 'src/libs/query/index.tsx';
 import http from 'src/services/api/index.ts';
-import type { User } from 'src/types/user.d.ts';
+import QUERY_KEYS from 'src/services/api/queryKey.ts';
 
 export type SubmitQuizAnswersRequest = { id: number; answer: number }[];
 
@@ -16,14 +14,13 @@ export interface SubmitQuizAnswersResponse {
 }
 
 export default function useSubmitTeamTypeQuizAnswers() {
-	const { user, setAuthData } = useAuth();
+	const { setAuthData } = useAuth();
 
 	const mutation = useMutation<SubmitQuizAnswersResponse, Error, SubmitQuizAnswersRequest>({
 		mutationFn: (data) => http.post('/personality-test', data),
-		onSuccess: ({ team, accessToken, url: encryptedUserId }) => {
-			const type = serverTeamEnumToClient[team];
-			const userData = { ...(user as User), type, encryptedUserId };
-			setAuthData({ userData, accessToken });
+		onSuccess: ({ accessToken }) => {
+			setAuthData({ accessToken });
+			queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.USER_INFO] });
 		},
 	});
 

--- a/packages/user/src/hooks/query/useUpdateShareLinkClickCount.ts
+++ b/packages/user/src/hooks/query/useUpdateShareLinkClickCount.ts
@@ -1,21 +1,15 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/naming-convention */
-import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
-import RoutePaths from 'src/constants/routePath.ts';
-import { useToast } from 'src/hooks/useToast.ts';
+import { useQuery } from '@tanstack/react-query';
 import http from 'src/services/api/index.ts';
+import QUERY_KEYS from 'src/services/api/queryKey.ts';
 
-export type SubmitQuizAnswersRequest = { id: string };
+export default function useUpdateShareLinkClickCount(id: string | undefined) {
+	const queries = useQuery(clickCountQueryOptions(id));
 
-export default function useUpdateShareLinkClickCount() {
-	const navigate = useNavigate();
-	const { toast } = useToast();
-	const mutation = useMutation<null, Error, SubmitQuizAnswersRequest>({
-		mutationFn: ({ id }) => http.post(`/share-link/${id}`),
-		onSettled: () => navigate(RoutePaths.Home, { replace: true }),
-		onError: () => toast({ description: '공유 링크 클릭 수 업데이트 중에 문제가 발생했습니다.' }),
-	});
-
-	return mutation;
+	return queries;
 }
+
+export const clickCountQueryOptions = (id: string | undefined) => ({
+	queryKey: [QUERY_KEYS.UPDATE_SHARE_COUNT, id],
+	queryFn: () => http.get(`/share-link/${id}`),
+	enabled: Boolean(id),
+});

--- a/packages/user/src/hooks/useInitialize.ts
+++ b/packages/user/src/hooks/useInitialize.ts
@@ -5,7 +5,7 @@ import useAuth from 'src/hooks/useAuth.ts';
 import type { User } from 'src/types/user.d.ts';
 
 export default function useInitialize() {
-	const { setAuthData } = useAuth();
+	const { user, setAuthData } = useAuth();
 	const { userInfo } = useGetUserInfo();
 
 	useEffect(() => {
@@ -16,6 +16,12 @@ export default function useInitialize() {
 
 			const userData: User = { id, name, type, encryptedUserId };
 			setAuthData({ userData });
+			/**
+			 * 유저 정보를 사용하는 컴포넌트 강제 리렌더링을 위함
+			 */
+			if (user?.encryptedUserId !== userData.encryptedUserId) {
+				window.location.reload();
+			}
 		}
 	}, [userInfo]);
 }

--- a/packages/user/src/hooks/useInitialize.ts
+++ b/packages/user/src/hooks/useInitialize.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
 import serverTeamEnumToClient from 'src/constants/serverMapping.ts';
 import useGetUserInfo from 'src/hooks/query/useGetUserInfo.ts';
 import useAuth from 'src/hooks/useAuth.ts';
@@ -6,9 +6,9 @@ import type { User } from 'src/types/user.d.ts';
 
 export default function useInitialize() {
 	const { user, setAuthData } = useAuth();
-	const { userInfo } = useGetUserInfo();
+	const { userInfo, ...options } = useGetUserInfo();
 
-	useEffect(() => {
+	const newUser = useMemo(() => {
 		if (userInfo) {
 			const { userName: name, userId: id, team, url: encryptedUserId } = userInfo;
 
@@ -16,12 +16,9 @@ export default function useInitialize() {
 
 			const userData: User = { id, name, type, encryptedUserId };
 			setAuthData({ userData });
-			/**
-			 * 유저 정보를 사용하는 컴포넌트 강제 리렌더링을 위함
-			 */
-			if (user?.encryptedUserId !== userData.encryptedUserId) {
-				window.location.reload();
-			}
+			return userData;
 		}
 	}, [userInfo]);
+
+	return { user, newUser, ...options };
 }

--- a/packages/user/src/pages/KakaoRedirectPage.tsx
+++ b/packages/user/src/pages/KakaoRedirectPage.tsx
@@ -16,10 +16,8 @@ export default function KakaoRedirectPage() {
 		if (!accessToken) {
 			throw new CustomError('로그인이 성공적으로 완료되지 않았습니다.', 400);
 		}
-		setToken(accessToken);
-
 		socketManager.reconnectSocketClient(accessToken);
-
+		setToken(accessToken);
 		navigate(RoutePaths.Event, { replace: true });
 	}, [accessToken]);
 

--- a/packages/user/src/routes/loader/share-redirect.ts
+++ b/packages/user/src/routes/loader/share-redirect.ts
@@ -1,0 +1,14 @@
+import { LoaderFunction, redirect } from 'react-router-dom';
+import RoutePaths from 'src/constants/routePath.ts';
+import { clickCountQueryOptions } from 'src/hooks/query/useUpdateShareLinkClickCount.ts';
+import { queryClient } from 'src/libs/query/index.tsx';
+
+const shareRedirectLoader: LoaderFunction = async ({ params }) => {
+	const { id } = params;
+
+	queryClient.fetchQuery(clickCountQueryOptions(id));
+
+	redirect(RoutePaths.Home);
+};
+
+export default shareRedirectLoader;

--- a/packages/user/src/routes/router.tsx
+++ b/packages/user/src/routes/router.tsx
@@ -11,10 +11,10 @@ import {
 	KakaoRedirectPage,
 	NotFoundErrorPage,
 	NotStartedEventPage,
-	ShareRedirectPage,
 } from 'src/pages/index.ts';
 
 import indexLoader from 'src/routes/loader/index.ts';
+import shareRedirectLoader from 'src/routes/loader/share-redirect.ts';
 
 const routes: RouteObject[] = [
 	{
@@ -29,8 +29,8 @@ const routes: RouteObject[] = [
 		children: [
 			{
 				path: '/:id',
-				element: <ShareRedirectPage />,
-				errorElement: <ErrorPage />,
+				loader: shareRedirectLoader,
+				element: null,
 			},
 			{
 				element: (

--- a/packages/user/src/services/api/queryKey.ts
+++ b/packages/user/src/services/api/queryKey.ts
@@ -1,6 +1,7 @@
 const QUERY_KEYS = {
 	EVENT_DURATION: 'event-duration',
-	LINK_SHARE_COUNT: 'link-share-count',
+	GET_LINK_SHARE_COUNT: 'get-link-share-count',
+	UPDATE_SHARE_COUNT: 'update-link-share-count',
 	TEAM_TYPE_QUIZ: 'team-type-quiz',
 	FCFS_QUIZ: 'fcfs-quiz',
 	USER_INFO: 'user-info',

--- a/packages/user/src/types/user.d.ts
+++ b/packages/user/src/types/user.d.ts
@@ -3,6 +3,6 @@ import type { Category } from '@softeer/common/types';
 export interface User {
 	id: string;
 	name: string;
-	type: Category | null;
-	encryptedUserId?: string | null;
+	type: Category | null | undefined;
+	encryptedUserId?: string | null | undefined;
 }


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용

- #72 에서 post로 구현했었던 공유 링크 생성 api method GET으로 수정해 구현
_-_ @bjh3311 님께서 count 수 증가를 조회수 개념으로 이해해 구현했다고 말씀해주셔서 유지하기로 결정

_ user 정보와, login token을 구현하면서 로그인했음에도 레이싱 카드 컴포넌트 업데이트가 되지 않는 문제가 발생
_-_ window.location.reload() 호출해 일차적으로 해결했으나.. 
_-_ 전체 페이지가 2번 로드되면서 깜박거리는 게 지난번부터 마음에 들지 않았고 굉장히 오래 다른 방법을 찾아 시행착오를 겪었습니다
_-_ 데이터 정보가 모두 업데이트 되기 전에는 pending 상태를 유지하도록 강제해 해결했습니다.

  <br/>
