### PR TITLE
[Feature][Task-258] 팀 유형 검사 두 번 이상 진행 불가하도록 설정

### DIFF
--- a/packages/user/src/components/event/racing/dashboard/card/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/index.tsx
@@ -1,5 +1,4 @@
-import { Category } from '@softeer/common/types';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import TriggerButtonWrapper from 'src/components/common/TriggerButtonWrapper.tsx';
 import TeamSelectModal, {
 	type TeamSelectModalProps,
@@ -13,24 +12,22 @@ const ProtectedTeamSelectModal = memo(withAuth<TeamSelectModalProps>(TeamSelectM
 
 export default function RacingCard() {
 	const { user } = useAuth();
-	const [type, setType] = useState<Category | null | undefined>(user?.type);
 
 	return (
 		<div className="bg-foreground/10 flex flex-col items-center rounded-[5px] p-4 pt-2 backdrop-blur-sm">
 			<CardTitle name={user?.name} />
-			{type && user?.encryptedUserId ? (
-				<ShareCountTeamCard type={type} encryptedUserId={user.encryptedUserId} size="racing" />
-			) : (
-				<ProtectedTeamSelectModal
-					openTrigger={
-						<TriggerButtonWrapper>
+			<ProtectedTeamSelectModal
+				openTrigger={
+					<TriggerButtonWrapper>
+						{user?.type ? (
+							<ShareCountTeamCard type={user.type} size="racing" />
+						) : (
 							<UnassignedCard />
-						</TriggerButtonWrapper>
-					}
-					onClose={() => setType(user?.type)}
-					unauthenticatedDisplay={<UnassignedCard />}
-				/>
-			)}
+						)}
+					</TriggerButtonWrapper>
+				}
+				unauthenticatedDisplay={<UnassignedCard />}
+			/>
 		</div>
 	);
 }

--- a/packages/user/src/components/shared/ShareCountTeamCard.tsx
+++ b/packages/user/src/components/shared/ShareCountTeamCard.tsx
@@ -3,29 +3,16 @@ import { Category } from '@softeer/common/types';
 import { Suspense } from 'react';
 import ShareIcon from 'src/assets/icons/share.svg?react';
 import useGetLinkShareCount from 'src/hooks/query/useGetLinkShareCount.ts';
-import copyLink from 'src/utils/copyLink.ts';
-import getSharedLink from 'src/utils/getSharedLink.ts';
 import TeamCardTemplate from './teamCardTemplate/index.tsx';
 
 type ShareCountTeamCardProps = {
 	type: Category;
-	encryptedUserId: string;
 	size: 'racing' | 'modal';
 };
-export default function ShareCountTeamCard({
-	type,
-	encryptedUserId,
-	size,
-}: ShareCountTeamCardProps) {
-	const url = getSharedLink({ type, encryptedUserId });
-
+export default function ShareCountTeamCard({ type, size }: ShareCountTeamCardProps) {
 	return (
 		<TeamCardTemplate type={type} size={size}>
-			<button
-				type="button"
-				onClick={() => copyLink(url)}
-				className="text-detail-3 bg-background flex items-center justify-center gap-3 rounded-[30px] px-[16px] py-[4px] text-center"
-			>
+			<div className="text-detail-3 bg-background flex items-center justify-center gap-3 rounded-[30px] px-[16px] py-[4px] text-center">
 				<ShareIcon />
 				<span>링크 클릭 수</span>
 				<span>|</span>
@@ -34,7 +21,7 @@ export default function ShareCountTeamCard({
 						<LinkShareCount />
 					</Suspense>
 				</span>
-			</button>
+			</div>
 		</TeamCardTemplate>
 	);
 }

--- a/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ModalContent.tsx
@@ -9,14 +9,16 @@ import ErrorStep from './ErrorStep.tsx';
 import ResultStep from './ResultStep.tsx';
 import QuizFunnel from './quiz/index.tsx';
 
-export default function TeamSelectModalContent() {
-	const [Funnel, setStep] = useFunnel([
-		'quiz',
-		'pending',
-		'success',
-		'error',
-		'already-done',
-	] as NonEmptyArray<string>);
+interface TeamSelectModalContentProps {
+	initialStep?: 'already-done' | 'quiz';
+}
+export default function TeamSelectModalContent({
+	initialStep = 'quiz',
+}: TeamSelectModalContentProps) {
+	const [Funnel, setStep] = useFunnel(
+		['quiz', 'pending', 'success', 'error', 'already-done'] as NonEmptyArray<string>,
+		{ initialStep },
+	);
 
 	const { mutate: submitAnswers, isPending } = useSubmitTeamTypeQuizAnswers();
 

--- a/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
@@ -5,7 +5,7 @@ import ShareCountTeamCard from 'src/components/shared/ShareCountTeamCard.tsx';
 import { TEAM_DESCRIPTIONS } from 'src/constants/teamDescriptions.ts';
 import useAuth from 'src/hooks/useAuth.ts';
 
-export default function ResultStep() {
+export default function ResultStep({ children }: PropsWithChildren) {
 	const { user } = useAuth();
 
 	const type = useMemo(() => user?.type as Category, [user]);
@@ -25,7 +25,8 @@ export default function ResultStep() {
 			/>
 			<div className="flex h-full max-w-lg flex-col justify-between gap-10 pb-12 pt-5 sm:max-w-xl md:max-h-[400px] md:pb-2">
 				<div>
-					<p className={`${titleStyles} text-heading-8 mb-6 whitespace-pre-line font-bold`}>
+					<div className="mb-4">{children}</div>
+					<p className={`${titleStyles} text-heading-8 mb-4 whitespace-pre-line font-bold`}>
 						<CategoryTitleTemplate>
 							<strong className="text-foreground">{displayTitle}</strong>
 						</CategoryTitleTemplate>
@@ -33,7 +34,7 @@ export default function ResultStep() {
 					<p className={`text-body-3 ${detailsStyles} break-words`}>{details}</p>
 				</div>
 				<div>
-					<p className="text-body-3 mb-4">내 링크 공유하고 추첨 당첨확률을 높여보세요!</p>
+					<p className="text-body-3 mb-3">내 링크 공유하고 추첨 당첨확률을 높여보세요!</p>
 					<LinkShare category={type} />
 				</div>
 			</div>

--- a/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/ResultStep.tsx
@@ -18,11 +18,7 @@ export default function ResultStep({ children }: PropsWithChildren) {
 
 	return (
 		<div className="grid h-full items-center gap-11 p-8 sm:p-12 md:grid-flow-col lg:p-16">
-			<ShareCountTeamCard
-				type={type}
-				size="modal"
-				encryptedUserId={user?.encryptedUserId as string}
-			/>
+			<ShareCountTeamCard type={type} size="modal" />
 			<div className="flex h-full max-w-lg flex-col justify-between gap-10 pb-12 pt-5 sm:max-w-xl md:max-h-[400px] md:pb-2">
 				<div>
 					<div className="mb-4">{children}</div>

--- a/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
+++ b/packages/user/src/components/shared/modal/teamSelectModal/index.tsx
@@ -12,7 +12,7 @@ export default function TeamSelectModal({ openTrigger, ...props }: TeamSelectMod
 	return (
 		<Modal variants={user?.type} openTrigger={openTrigger} {...props}>
 			<Suspense fallback={<PendingStep>유형 검사 리스트 불러오는 중 ...</PendingStep>}>
-				<TeamSelectModalContent />
+				<TeamSelectModalContent initialStep={user?.type ? 'already-done' : 'quiz'} />
 			</Suspense>
 		</Modal>
 	);

--- a/packages/user/src/hooks/useInitialize.ts
+++ b/packages/user/src/hooks/useInitialize.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import serverTeamEnumToClient from 'src/constants/serverMapping.ts';
 import useGetUserInfo from 'src/hooks/query/useGetUserInfo.ts';
 import useAuth from 'src/hooks/useAuth.ts';
@@ -15,10 +15,13 @@ export default function useInitialize() {
 			const type = team ? serverTeamEnumToClient[team] : null;
 
 			const userData: User = { id, name, type, encryptedUserId };
-			setAuthData({ userData });
 			return userData;
 		}
 	}, [userInfo]);
+
+	useEffect(() => {
+		setAuthData({ userData: newUser });
+	}, [newUser]);
 
 	return { user, newUser, ...options };
 }


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
> 제 카카오 계정 상으로는,, 이미 유형 검사가 완료된 상태여서 다른 케이스에 대해 확인해보진 못했습니다. 
내일 QA 진행하면서 모든 플로우 재확인 예정입니다

as-is:서버에서 유형 검사 가능 횟수 제한 없음

to-be: 성격 유형 검사 두 번 이상 진행 불가하도록 설정
- 클라이언트에서는 새로고침 할 떄마다 user data를 새로 받아와 업데이트 해주기 때문에, 중복 검사할 가능성은 드물지만, 가산점을 노리고 악의적으로 팀 변경 요청할 가능성을 고려해 @bjh3311 님께 요청해 진행
- 결과 제출 시 400 status 일 경우 `이미 검사 완료되었다는 문구가 포함된 결과 페이지(A)`를 띄워주기
- 유형 검사 모달 열 때 client에 저장된 유저 정보를 확인해 팀이 존재할 경우 A를 바로 띄워주도록 처리


  <br/>

## 이미지 첨부
<img width="817" alt="스크린샷 2024-08-18 오후 8 28 25" src="https://github.com/user-attachments/assets/6e75b8a9-2d20-4fea-b41c-897187d8897e">

<br/>
