### PR TITLE
[Feature][Task-243] 레이싱 화면 내 클릭용, 순위 표기 용 버튼 역할 분리 & 유형 검사 해야 클릭 버튼이 노출되도록 하고 내 팀만 응원하기

### DIFF
--- a/packages/user/src/components/event/racing/controls/ChargeButtonWrapper.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonWrapper.tsx
@@ -1,5 +1,5 @@
 import type { Category } from '@softeer/common/types';
-import { ButtonHTMLAttributes } from 'react';
+import { PropsWithChildren } from 'react';
 import GradientBorderWrapper from 'src/components/common/GradientBorderWrapper.tsx';
 
 const imageUrls: Record<Category, string> = {
@@ -9,26 +9,26 @@ const imageUrls: Record<Category, string> = {
 	pet: '/images/racing/side/pet.png',
 };
 
-interface ChargeButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+interface ChargeButtonWrapperProps {
 	type: Category;
+	isActive: boolean;
 }
 
 export default function ChargeButtonWrapper({
 	type,
-	disabled = false,
+	isActive,
 	children,
-	...props
-}: ChargeButtonProps) {
+}: PropsWithChildren<ChargeButtonWrapperProps>) {
 	const imageUrl = imageUrls[type];
-	const styles = getStyles({ type, isActive: !disabled });
+	const styles = getStyles({ type, isActive });
 
 	return (
-		<button type="button" disabled={disabled} className={styles.button} {...props}>
+		<div className={styles.container}>
 			<GradientBorderWrapper className={styles.borderWrapper}>
 				<div className={styles.innerborderWrapper}>{children}</div>
 			</GradientBorderWrapper>
 			<img src={imageUrl} alt={`${type} 팀 캐스퍼 실물`} className={styles.image} />
-		</button>
+		</div>
 	);
 }
 
@@ -44,7 +44,7 @@ function getStyles({ type, isActive }: { type: Category; isActive: boolean }) {
 
 	return {
 		image: `${imageBaseStyles} ${isActive ? 'transition-transform duration-300 ease-out group-active:scale-125' : ''}`,
-		button: 'relative overflow-visible group disabled:opacity-50',
+		container: 'relative overflow-visible group disabled:opacity-50',
 		borderWrapper: isActive ? 'group-active:animate-rotate' : '',
 		innerborderWrapper: `flex h-[84px] w-[240px] gap-7 rounded-[inherit] px-[10px] py-[10px] ${bgStyles[type]}`,
 	};

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -2,6 +2,7 @@ import type { Category } from '@softeer/common/types';
 import numeral from 'numeral';
 
 import { useMemo } from 'react';
+import useAuth from 'src/hooks/useAuth.ts';
 import type { Rank } from 'src/types/racing.d.ts';
 import ChargeButtonContent from './ChargeButtonContent.tsx';
 import ChargeButtonWrapper from './ChargeButtonWrapper.tsx';
@@ -21,6 +22,7 @@ export interface ChargeButtonData {
 }
 
 export default function ControlButton({ isActive, type, data }: ControlButtonProps) {
+	const { user } = useAuth();
 	const { rank, vote, percentage } = data;
 
 	const displayVoteStats = useMemo(
@@ -28,10 +30,12 @@ export default function ControlButton({ isActive, type, data }: ControlButtonPro
 		[percentage, vote],
 	);
 
+	const isMyCasperActivated = isActive && user?.type === type;
+
 	return (
 		<ControllButtonWrapper rank={rank}>
-			<Gauge percentage={percentage} isActive={isActive} />
-			<ChargeButtonWrapper type={type} isActive={isActive}>
+			<Gauge percentage={percentage} isActive={isMyCasperActivated} />
+			<ChargeButtonWrapper type={type} isActive={isMyCasperActivated}>
 				<ChargeButtonContent type={type} rank={rank}>
 					{displayVoteStats}
 				</ChargeButtonContent>

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -1,8 +1,7 @@
 import type { Category } from '@softeer/common/types';
 import numeral from 'numeral';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import useAuth from 'src/hooks/useAuth.ts';
-import { useToast } from 'src/hooks/useToast.ts';
+
+import { useMemo } from 'react';
 import type { Rank } from 'src/types/racing.d.ts';
 import ChargeButtonContent from './ChargeButtonContent.tsx';
 import ChargeButtonWrapper from './ChargeButtonWrapper.tsx';
@@ -12,8 +11,7 @@ import Gauge from './Gauge.tsx';
 interface ControlButtonProps {
 	type: Category;
 	data: ChargeButtonData;
-	onCharge: () => void;
-	onFullyCharged: () => void;
+	isActive: boolean;
 }
 
 export interface ChargeButtonData {
@@ -22,18 +20,8 @@ export interface ChargeButtonData {
 	percentage: number;
 }
 
-export default function ControlButton({
-	onCharge,
-	onFullyCharged,
-	type,
-	data,
-}: ControlButtonProps) {
+export default function ControlButton({ isActive, type, data }: ControlButtonProps) {
 	const { rank, vote, percentage } = data;
-	const { progress, handleClick } = useGaugeProgress({
-		percentage,
-		onCharge,
-		onFullyCharged,
-	});
 
 	const displayVoteStats = useMemo(
 		() => `${percentage.toFixed(1)}% (${formatVoteCount(vote)})`,
@@ -42,44 +30,14 @@ export default function ControlButton({
 
 	return (
 		<ControllButtonWrapper rank={rank}>
-			<Gauge percent={progress} />
-			<ChargeButtonWrapper onClick={handleClick} type={type}>
+			<Gauge percentage={percentage} isActive={isActive} />
+			<ChargeButtonWrapper type={type} isActive={isActive}>
 				<ChargeButtonContent type={type} rank={rank}>
 					{displayVoteStats}
 				</ChargeButtonContent>
 			</ChargeButtonWrapper>
 		</ControllButtonWrapper>
 	);
-}
-
-/** Custom Hook */
-function useGaugeProgress({
-	percentage,
-	onCharge,
-	onFullyCharged,
-}: {
-	percentage: number;
-	onCharge: () => void;
-	onFullyCharged: () => void;
-}) {
-	const { toast } = useToast();
-	const { isAuthenticated } = useAuth();
-
-	const [progress, setProgress] = useState(percentage);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-	useEffect(() => setProgress(percentage), [percentage]);
-
-	const handleClick = useCallback(() => {
-		setProgress(100);
-		onCharge();
-		onFullyCharged();
-
-		if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		timeoutRef.current = setTimeout(() => setProgress(percentage), 500);
-	}, [onCharge, onFullyCharged, isAuthenticated, percentage, toast]);
-
-	return { progress, handleClick };
 }
 
 /** Utility Functions */

--- a/packages/user/src/components/event/racing/controls/ControlButton.tsx
+++ b/packages/user/src/components/event/racing/controls/ControlButton.tsx
@@ -33,7 +33,7 @@ export default function ControlButton({ isActive, type, data }: ControlButtonPro
 	const isMyCasperActivated = isActive && user?.type === type;
 
 	return (
-		<ControllButtonWrapper rank={rank}>
+		<ControllButtonWrapper isMyCasper={user?.type ? user?.type === type : true} rank={rank}>
 			<Gauge percentage={percentage} isActive={isMyCasperActivated} />
 			<ChargeButtonWrapper type={type} isActive={isMyCasperActivated}>
 				<ChargeButtonContent type={type} rank={rank}>

--- a/packages/user/src/components/event/racing/controls/ControllButtonWrapper.tsx
+++ b/packages/user/src/components/event/racing/controls/ControllButtonWrapper.tsx
@@ -3,17 +3,19 @@ import type { Rank } from 'src/types/racing.d.ts';
 
 interface ControllButtonWrapperProps {
 	rank: Rank;
+	isMyCasper: boolean;
 }
 
 export default function ControllButtonWrapper({
 	rank,
+	isMyCasper,
 	children,
 }: PropsWithChildren<ControllButtonWrapperProps>) {
 	const rankStyle = useMemo(() => styles[rank], [rank]);
 
 	return (
 		<div
-			className={`absolute flex transform flex-col gap-3 transition-all duration-500 ease-in-out ${rankStyle}`}
+			className={`${isMyCasper ? 'scale-100' : 'scale-75 opacity-60'} absolute flex transform flex-col gap-3 transition-all duration-500 ease-in-out ${rankStyle}`}
 		>
 			{children}
 		</div>

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -42,7 +42,7 @@ function useGaugeProgress({ percentage, isActive }: GaugeProps) {
 		setProgress(100);
 
 		if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		timeoutRef.current = setTimeout(() => setProgress(percentage), 500);
+		timeoutRef.current = setTimeout(() => setProgress(percentage), 700);
 	}, [isActive]);
 
 	return { progress };

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -1,16 +1,21 @@
-import { memo, useMemo } from 'react';
+/* eslint-disable react/no-unused-prop-types */
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import Lightning from 'src/assets/icons/lighting.svg?react';
 
 interface GaugeProps {
-	percent: number;
+	percentage: number;
+	isActive: boolean;
 }
-const Gauge = memo(({ percent }: GaugeProps) => {
+
+const Gauge = memo((props: GaugeProps) => {
+	const { progress } = useGaugeProgress(props);
+
 	const backgroundColor = useMemo(() => {
-		if (percent < 22) return 'bg-gradient-gauge1';
-		if (percent < 57) return 'bg-gradient-gauge2';
-		if (percent < 88) return 'bg-gradient-gauge3';
+		if (progress < 22) return 'bg-gradient-gauge1';
+		if (progress < 57) return 'bg-gradient-gauge2';
+		if (progress < 88) return 'bg-gradient-gauge3';
 		return 'bg-gradient-gauge4';
-	}, [percent]);
+	}, [progress]);
 
 	return (
 		<div className="flex items-center gap-2">
@@ -18,7 +23,7 @@ const Gauge = memo(({ percent }: GaugeProps) => {
 			<div className="relative h-[4px] w-full rounded-[2px] bg-neutral-600">
 				<div
 					className={`ease-&lsqb;cubic-bezier(0.14,0.63,0.82,0.72)&rsqb; absolute z-10 h-full transform rounded-[2px] transition-all duration-700 ${backgroundColor}`}
-					style={{ width: `${percent.toFixed(0)}%` }}
+					style={{ width: `${progress.toFixed(0)}%` }}
 				/>
 			</div>
 		</div>
@@ -26,3 +31,19 @@ const Gauge = memo(({ percent }: GaugeProps) => {
 });
 
 export default Gauge;
+
+function useGaugeProgress({ percentage, isActive }: GaugeProps) {
+	const [progress, setProgress] = useState(percentage);
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => setProgress(percentage), [percentage]);
+
+	useEffect(() => {
+		setProgress(100);
+
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(() => setProgress(percentage), 500);
+	}, [isActive]);
+
+	return { progress };
+}

--- a/packages/user/src/components/event/racing/controls/Gauge.tsx
+++ b/packages/user/src/components/event/racing/controls/Gauge.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
-import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import Lightning from 'src/assets/icons/lighting.svg?react';
+import useTimeoutEffect from 'src/hooks/useTimeoutEffect.ts';
 
 interface GaugeProps {
 	percentage: number;
@@ -34,15 +35,13 @@ export default Gauge;
 
 function useGaugeProgress({ percentage, isActive }: GaugeProps) {
 	const [progress, setProgress] = useState(percentage);
-	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	useEffect(() => setProgress(percentage), [percentage]);
+	useTimeoutEffect(() => setProgress(percentage), 200, [isActive]);
 
 	useEffect(() => {
-		setProgress(100);
-
-		if (timeoutRef.current) clearTimeout(timeoutRef.current);
-		timeoutRef.current = setTimeout(() => setProgress(percentage), 700);
+		if (isActive) {
+			setProgress(100);
+		}
 	}, [isActive]);
 
 	return { progress };

--- a/packages/user/src/components/event/racing/controls/index.tsx
+++ b/packages/user/src/components/event/racing/controls/index.tsx
@@ -1,19 +1,17 @@
 import { CATEGORIES } from '@softeer/common/constants';
-import { Category } from '@softeer/common/types';
 import { useMemo } from 'react';
 import type { UseRacingSocketReturnType } from 'src/hooks/socket/useRacingSocket.ts';
 import type { VoteStatus } from 'src/types/racing.d.ts';
 import ControlButton from './ControlButton.tsx';
 
-interface RacingControlsProps extends Omit<UseRacingSocketReturnType, 'onReceiveStatus'> {
-	onCharge: (type: Category) => void;
+interface RacingRankingDisplayProps extends Pick<UseRacingSocketReturnType, 'ranks' | 'votes'> {
+	isActive: boolean;
 }
-export default function RacingControls({
+export default function RacingRankingDisplay({
+	isActive,
 	ranks,
 	votes,
-	onCharge,
-	onCarFullyCharged,
-}: RacingControlsProps) {
+}: RacingRankingDisplayProps) {
 	const percentage = useMemo(() => calculatePercentage(votes), [votes]);
 
 	return (
@@ -22,13 +20,12 @@ export default function RacingControls({
 				<ControlButton
 					key={type}
 					type={type}
+					isActive={isActive}
 					data={{
 						rank: ranks[type],
 						percentage: percentage[type],
 						vote: votes[type],
 					}}
-					onFullyCharged={() => onCarFullyCharged(type)}
-					onCharge={() => onCharge(type)}
 				/>
 			))}
 		</div>

--- a/packages/user/src/components/event/racing/dashboard/Casper.tsx
+++ b/packages/user/src/components/event/racing/dashboard/Casper.tsx
@@ -1,5 +1,5 @@
 import type { Category } from '@softeer/common/types';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import MarkerIcon from 'src/assets/icons/car-marker.svg?react';
 import useAuth from 'src/hooks/useAuth.ts';
 import type { Rank } from 'src/types/racing.d.ts';
@@ -7,18 +7,21 @@ import type { Rank } from 'src/types/racing.d.ts';
 interface CasperProps {
 	type: Category;
 	rank: Rank;
-	className: string;
+	isActive: boolean;
 }
 
-const Casper = memo(({ type, rank, className }: CasperProps) => {
+const Casper = memo(({ type, rank, isActive }: CasperProps) => {
 	const { user } = useAuth();
-	const isMyCasper = user?.type === type;
-
+	const isMyCasper = useMemo(() => user?.type === type, [user?.type, type]);
+	const activeStyles = useMemo(
+		() => (isActive && isMyCasper ? 'scale-125' : ''),
+		[isActive, isMyCasper],
+	);
 	return (
 		<div
-			className={`absolute flex flex-col items-center gap-8 ${className} ${rankStyles[rank]} ${transitionStyles}`}
+			className={`absolute flex flex-col items-center gap-8 ${activeStyles} ${rankStyles[rank]} ${transitionStyles}`}
 		>
-			<div className="h-[10px]">{isMyCasper && <MarkerIcon />}</div>
+			<div className="h-[20px]">{isMyCasper && <MarkerIcon />}</div>
 			<img src={imageUrls[type]} alt={`${rank}등 차`} className="object-contain" />
 		</div>
 	);
@@ -28,10 +31,10 @@ export default Casper;
 const transitionStyles = 'transform transition-all duration-700 ease-in-out';
 
 const rankStyles: Record<Rank, string> = {
-	1: 'w-[335px] left-[380px] top-[295px] z-40 rotate-0',
-	2: 'w-[270px] left-[170px] top-[335px] z-30 -rotate-[4deg]',
-	3: 'w-[200px] left-[700px] top-[360px] z-20 rotate-6',
-	4: 'w-[120px] left-[900px] top-[410px] z-10 rotate-[5deg]',
+	1: 'w-[335px] left-[380px] top-[285px] z-40 rotate-0',
+	2: 'w-[270px] left-[170px] top-[325px] z-30 -rotate-[4deg]',
+	3: 'w-[200px] left-[700px] top-[350px] z-20 rotate-6',
+	4: 'w-[120px] left-[900px] top-[400px] z-10 rotate-[5deg]',
 };
 
 const imageUrls: Record<Category, string> = {

--- a/packages/user/src/components/event/racing/dashboard/Casper.tsx
+++ b/packages/user/src/components/event/racing/dashboard/Casper.tsx
@@ -26,6 +26,7 @@ const Casper = memo(({ type, rank, isActive }: CasperProps) => {
 		</div>
 	);
 });
+
 export default Casper;
 
 const transitionStyles = 'transform transition-all duration-700 ease-in-out';

--- a/packages/user/src/components/event/racing/dashboard/chargeButton.tsx
+++ b/packages/user/src/components/event/racing/dashboard/chargeButton.tsx
@@ -1,0 +1,14 @@
+interface ChargeButtonProps {
+	onCharge: () => void;
+}
+export default function ChargeButton({ onCharge }: ChargeButtonProps) {
+	return (
+		<button
+			type="button"
+			onClick={onCharge}
+			className="bg-skyblue-500 absolute right-[27px] top-[95px] w-[300px]"
+		>
+			chargeButton
+		</button>
+	);
+}

--- a/packages/user/src/components/event/racing/dashboard/chargeButton.tsx
+++ b/packages/user/src/components/event/racing/dashboard/chargeButton.tsx
@@ -1,14 +1,26 @@
+import { memo } from 'react';
+import useAuth from 'src/hooks/useAuth.ts';
+
 interface ChargeButtonProps {
 	onCharge: () => void;
 }
-export default function ChargeButton({ onCharge }: ChargeButtonProps) {
+const ChargeButton = memo(({ onCharge }: ChargeButtonProps) => {
+	const { user } = useAuth();
+
+	if (!user?.type) {
+		return null;
+	}
+
 	return (
 		<button
 			type="button"
 			onClick={onCharge}
-			className="bg-skyblue-500 absolute right-[27px] top-[95px] w-[300px]"
+			className="bg-skyblue-400 absolute bottom-12 right-[27px] top-[130px] z-50 flex h-[140px] min-w-[150px] flex-col items-center justify-center gap-3 break-keep rounded-[25px] px-6 py-4 text-center font-medium text-yellow-900 opacity-90 shadow-lg"
 		>
-			chargeButton
+			<p className="text-body-1 font-bold">1등을 차지하는</p>
+			<h3 className="text-foreground">충전 버튼</h3>
 		</button>
 	);
-}
+});
+
+export default ChargeButton;

--- a/packages/user/src/components/event/racing/dashboard/index.tsx
+++ b/packages/user/src/components/event/racing/dashboard/index.tsx
@@ -1,5 +1,4 @@
 import { CATEGORIES } from '@softeer/common/constants';
-import type { Category } from '@softeer/common/types';
 import { memo } from 'react';
 import EventTimer from 'src/components/shared/timer/index.tsx';
 import useGetEventDuration from 'src/hooks/query/useGetEventDuration.ts';
@@ -10,23 +9,18 @@ import Casper from './Casper.tsx';
 import RacingTitle from './RacingTitle.tsx';
 
 interface RacingDashboardProps extends Pick<UseRacingSocketReturnType, 'ranks'> {
-	chargedCar: Category | null;
+	isActive: boolean;
 }
 
-const RacingDashboard = memo(({ ranks, chargedCar }: RacingDashboardProps) => (
-	<div className="relative h-[685px] w-full">
+const RacingDashboard = memo(({ ranks, isActive }: RacingDashboardProps) => (
+	<>
 		<HeaderSection />
 		<RacingCardSection />
 		{CATEGORIES.map((type) => (
-			<Casper
-				key={type}
-				type={type}
-				rank={ranks[type]}
-				className={chargedCar === type ? 'scale-110' : ''}
-			/>
+			<Casper key={type} type={type} rank={ranks[type]} isActive={isActive} />
 		))}
 		<Background />
-	</div>
+	</>
 ));
 
 export default RacingDashboard;

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -1,7 +1,8 @@
-import { Category } from '@softeer/common/types';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import ChargeButton from 'src/components/event/racing/dashboard/chargeButton.tsx';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
+import useTimeoutEffect from 'src/hooks/useTimeoutEffect.ts';
 import RacingRankingDisplay from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
@@ -9,17 +10,33 @@ import RacingDashboard from './dashboard/index.tsx';
 export default function RealTimeRacing({
 	racingSocket,
 }: Pick<UseSocketReturnType, 'racingSocket'>) {
-	const [chargedCar] = useState<Category | null>(null);
+	const { ranks, votes, onCarFullyCharged } = racingSocket;
 
-	const { ranks, votes } = racingSocket;
+	const { isCharged, handleCharge } = useChargeHandler(onCarFullyCharged);
 
 	return (
 		<section
 			id={SECTION_ID.RACING}
 			className="container flex w-[1200px] snap-start flex-col items-center gap-4 pb-[50px] pt-[80px]"
 		>
-			<RacingDashboard ranks={ranks} chargedCar={chargedCar} />
-			<RacingRankingDisplay votes={votes} ranks={ranks} isActive />
+			<div className="relative h-[685px] w-full">
+				<RacingDashboard ranks={ranks} isActive={isCharged} />
+				<ChargeButton onCharge={handleCharge} />
+			</div>
+			<RacingRankingDisplay votes={votes} ranks={ranks} isActive={isCharged} />
 		</section>
 	);
+}
+
+function useChargeHandler(onCarFullyCharged: () => void) {
+	const [isCharged, setCharge] = useState(false);
+
+	useTimeoutEffect(() => setCharge(false), 200, [isCharged]);
+
+	const handleCharge = useCallback(() => {
+		setCharge(true);
+		onCarFullyCharged();
+	}, [onCarFullyCharged]);
+
+	return { isCharged, handleCharge };
 }

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -23,5 +23,3 @@ export default function RealTimeRacing({
 		</section>
 	);
 }
-
-/** Progress  */

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -2,16 +2,16 @@ import { Category } from '@softeer/common/types';
 import { useState } from 'react';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
-import RacingControls from './controls/index.tsx';
+import RacingRankingDisplay from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
 export default function RealTimeRacing({
 	racingSocket,
 }: Pick<UseSocketReturnType, 'racingSocket'>) {
-	const [chargedCar, setChargedCar] = useState<Category | null>(null);
+	const [chargedCar] = useState<Category | null>(null);
 
-	const { ranks, votes, onCarFullyCharged } = racingSocket;
+	const { ranks, votes } = racingSocket;
 
 	return (
 		<section
@@ -19,12 +19,9 @@ export default function RealTimeRacing({
 			className="container flex w-[1200px] snap-start flex-col items-center gap-4 pb-[50px] pt-[80px]"
 		>
 			<RacingDashboard ranks={ranks} chargedCar={chargedCar} />
-			<RacingControls
-				votes={votes}
-				ranks={ranks}
-				onCarFullyCharged={onCarFullyCharged}
-				onCharge={setChargedCar}
-			/>
+			<RacingRankingDisplay votes={votes} ranks={ranks} isActive />
 		</section>
 	);
 }
+
+/** Progress  */

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -1,18 +1,14 @@
-import { useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import ChargeButton from 'src/components/event/racing/dashboard/chargeButton.tsx';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
-import useAuth from 'src/hooks/useAuth.ts';
 import useTimeoutEffect from 'src/hooks/useTimeoutEffect.ts';
 import RacingRankingDisplay from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
-export default function RealTimeRacing({
-	racingSocket,
-}: Pick<UseSocketReturnType, 'racingSocket'>) {
+const RealTimeRacing = memo(({ racingSocket }: Pick<UseSocketReturnType, 'racingSocket'>) => {
 	const { ranks, votes, onCarFullyCharged } = racingSocket;
-	const { user } = useAuth();
 	const { isCharged, handleCharge } = useChargeHandler(onCarFullyCharged);
 
 	return (
@@ -22,12 +18,14 @@ export default function RealTimeRacing({
 		>
 			<div className="relative h-[685px] w-full">
 				<RacingDashboard ranks={ranks} isActive={isCharged} />
-				{user?.type && <ChargeButton onCharge={handleCharge} />}
+				<ChargeButton onCharge={handleCharge} />
 			</div>
 			<RacingRankingDisplay votes={votes} ranks={ranks} isActive={isCharged} />
 		</section>
 	);
-}
+});
+
+export default RealTimeRacing;
 
 function useChargeHandler(onCarFullyCharged: () => void) {
 	const [isCharged, setCharge] = useState(false);

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import ChargeButton from 'src/components/event/racing/dashboard/chargeButton.tsx';
 import SECTION_ID from 'src/constants/sectionId.ts';
 import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
+import useAuth from 'src/hooks/useAuth.ts';
 import useTimeoutEffect from 'src/hooks/useTimeoutEffect.ts';
 import RacingRankingDisplay from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
@@ -11,7 +12,7 @@ export default function RealTimeRacing({
 	racingSocket,
 }: Pick<UseSocketReturnType, 'racingSocket'>) {
 	const { ranks, votes, onCarFullyCharged } = racingSocket;
-
+	const { user } = useAuth();
 	const { isCharged, handleCharge } = useChargeHandler(onCarFullyCharged);
 
 	return (
@@ -21,7 +22,7 @@ export default function RealTimeRacing({
 		>
 			<div className="relative h-[685px] w-full">
 				<RacingDashboard ranks={ranks} isActive={isCharged} />
-				<ChargeButton onCharge={handleCharge} />
+				{user?.type && <ChargeButton onCharge={handleCharge} />}
 			</div>
 			<RacingRankingDisplay votes={votes} ranks={ranks} isActive={isCharged} />
 		</section>

--- a/packages/user/src/components/layout/index.tsx
+++ b/packages/user/src/components/layout/index.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from 'react-router-dom';
+import DeferredWrapper from 'src/components/common/DeferredWrapper.tsx';
 import PendingContainer from 'src/components/common/PendingContainer.tsx';
 import useInitialize from 'src/hooks/useInitialize.ts';
 import Banner from './banner/index.tsx';
@@ -12,7 +13,11 @@ export default function Layout() {
 	const { user, newUser, isFetching } = useInitialize();
 
 	if (isFetching || user?.encryptedUserId !== newUser?.encryptedUserId) {
-		return <PendingContainer message="사용자 정보를 불러오고 있습니다!" />;
+		return (
+			<DeferredWrapper>
+				<PendingContainer message="사용자 정보를 불러오고 있습니다!" />
+			</DeferredWrapper>
+		);
 	}
 
 	return (

--- a/packages/user/src/hooks/socket/useRacingSocket.ts
+++ b/packages/user/src/hooks/socket/useRacingSocket.ts
@@ -7,6 +7,7 @@ import { Category } from '@softeer/common/types';
 import type { SocketSubscribeCallbackType } from '@softeer/common/utils';
 import { useCallback, useMemo, useState } from 'react';
 import useRacingVoteStorage from 'src/hooks/storage/useRacingVoteStorage.ts';
+import useAuth from 'src/hooks/useAuth.ts';
 import { useToast } from 'src/hooks/useToast.ts';
 import socketManager from 'src/services/socket.ts';
 import type { Rank, SocketCategory, VoteStatus } from 'src/types/racing.d.ts';
@@ -17,6 +18,7 @@ type SocketData = Record<SocketCategory, number>;
 
 export default function useRacingSocket() {
 	const { toast } = useToast();
+	const { user } = useAuth();
 
 	const socketClient = socketManager.getSocketClient();
 
@@ -42,7 +44,9 @@ export default function useRacingSocket() {
 		[votes],
 	);
 
-	const handleCarFullyCharged = useCallback((category: Category) => {
+	const handleCarFullyCharged = useCallback(() => {
+		const category = user?.type as Category;
+
 		const chargeData = { [categoryToSocketCategory[category].toLowerCase()]: 1 };
 
 		const completeChargeData = Object.keys(categoryToSocketCategory).reduce(
@@ -63,7 +67,7 @@ export default function useRacingSocket() {
 			const errorMessage = (error as Error).message;
 			toast({ description: errorMessage.length > 0 ? errorMessage : '문제가 발생했습니다.' });
 		}
-	}, []);
+	}, [user?.type]);
 
 	return {
 		votes,

--- a/packages/user/src/hooks/useTimeoutEffect.ts
+++ b/packages/user/src/hooks/useTimeoutEffect.ts
@@ -1,0 +1,14 @@
+import { useEffect, useRef } from 'react';
+
+export default function useTimeoutEffect(callback: () => void, delay: number, deps: any[] = []) {
+	const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		timeoutRef.current = setTimeout(callback, delay);
+
+		return () => {
+			if (timeoutRef.current) clearTimeout(timeoutRef.current);
+		};
+	}, deps);
+}


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
> @jun-ha님과 레이싱 고도화 관련 회의를 진행했고 다음과 같은 태스크를 산정해 진행
현재 소켓 관련 기능이 서버-클라이언트 모두 수정이 필요한 상태라 완벽히 테스트해보진 못한 상황입니다.

### as-is
> 회의 내용 때 나온 여러 의견 중 이번 작업과 연관 있는 논의 사항 
- rank/득표수 표기 & 클릭 control 이 하나의 컴포넌트에서 모두 진행 
_-_ 그러다보니 버튼을 클릭하는 중에 순위가 바뀌면 불편해짐
- 내 팀만 클릭 할 수 있는 플로우가 더 자연스럽지 않을까

### to-be
- [x]  클릭용, 순위 표기 용 버튼 역할 분리
- [x]  내 팀 외 다른 버튼 disabled
- [x]  유형 검사 해야 클릭 버튼이 노출되도록



  <br/>

## 이미지 첨부

![스크린샷 2024-08-18 오후 10 35 39](https://github.com/user-attachments/assets/311b2310-f891-4032-8872-86c72b9b9c2a)
ㄴ 로그인 안 한 상태

![스크린샷 2024-08-18 오후 10 35 13](https://github.com/user-attachments/assets/c05f779d-70fd-4c25-ab50-1050855f475e)
ㄴ 로그인 , 유형 검사 완료한 상태

<br/>
