### PR TITLE
[Feature][Task-132] 헷갈릴 수 있는 ui/ux 에 안내 문구 추가 

### DIFF
--- a/packages/user/src/components/home/eventSteps/StepThird.tsx
+++ b/packages/user/src/components/home/eventSteps/StepThird.tsx
@@ -1,4 +1,5 @@
 import LinkShare from 'src/components/shared/linkShare/index.tsx';
+import useAuth from 'src/hooks/useAuth.ts';
 import ContentCard from './ContentCard.tsx';
 import ContentsContainer from './ContentsContainer.tsx';
 
@@ -12,10 +13,21 @@ export default function StepThird() {
 }
 
 function CopyAndShare() {
+	const { user } = useAuth();
+
 	return (
-		<div className="flex w-[595px] flex-col items-center gap-7">
+		<div className="flex w-[595px] flex-col items-center">
 			<LinkShare />
-			<p className="text-body-3 font-medium">링크를 복사하고 친구에게 공유하기</p>
+			<p className="text-body-3 mb-3 mt-7 font-medium">
+				{user?.type ? (
+					'링크를 복사하고 친구에게 공유하기'
+				) : (
+					<>
+						나의 <strong>캐스퍼 유형</strong> 확인하고 <strong>나만의 공유 링크</strong>를 만들어
+						보세요!
+					</>
+				)}
+			</p>
 		</div>
 	);
 }

--- a/packages/user/src/components/home/fastestQuiz/TopSection.tsx
+++ b/packages/user/src/components/home/fastestQuiz/TopSection.tsx
@@ -2,9 +2,10 @@ import { PropsWithChildren } from 'react';
 
 export default function TopSection() {
 	return (
-		<div className="flex flex-col items-center gap-6">
+		<div className="flex flex-col items-center">
 			<Highlight>매일 3시 15분!</Highlight>
-			<h2>깜짝 선착순 퀴즈 OPEN</h2>
+			<h2 className="mb-2 mt-6">깜짝 선착순 퀴즈 OPEN</h2>
+			<p className="text-body-3 text-neutral-200">* 아래 사진은 선착순 퀴즈 팝업 예시입니다</p>
 		</div>
 	);
 }

--- a/packages/user/src/components/home/teamsDescriptions/index.tsx
+++ b/packages/user/src/components/home/teamsDescriptions/index.tsx
@@ -29,7 +29,7 @@ export default function TeamsDescriptions() {
 						/>
 					))}
 				</div>
-				<Button size="lg" onClick={goDetailDescriptions}>
+				<Button className="underline" size="lg" onClick={goDetailDescriptions}>
 					자세한 설명 보러가기
 				</Button>
 			</div>

--- a/packages/user/src/components/shared/linkShare/index.tsx
+++ b/packages/user/src/components/shared/linkShare/index.tsx
@@ -21,7 +21,6 @@ export default function LinkShare({ category }: LinkShareProps) {
 	return (
 		<div className="flex gap-4">
 			<LinkDisplay variants={variants} value={url} />
-			{/* Todo: 유형 검사 완료해야 가산점 받을 수 있다는 안내 tooltip 추가 */}
 			{category ? (
 				<LinkShareButton onClick={handleCopy} variants={category} />
 			) : (


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용

- 유형 검사 완료한 뒤 링크 생성된다는 안내 문구 추가
![스크린샷 2024-08-19 오전 1 56 17](https://github.com/user-attachments/assets/16d52389-e7be-4684-ae78-66909f91a2bc)

- 선착순 퀴즈 팝업 예시 사진 안내 문구 추가
![스크린샷 2024-08-19 오전 1 56 48](https://github.com/user-attachments/assets/c8b4d4b1-c8bf-4b7c-8388-8027bbb6379a)

- 자세한 설명 보러가기 버튼에 외부 링크 이동임을 표기
![스크린샷 2024-08-19 오전 1 56 36](https://github.com/user-attachments/assets/60a29ce1-eee6-4657-8506-b885218e2c0d)

  <br/>
