### PR TITLE
[Fix] 유저 정보 불러오는 중에 문제 로그인 정보 만료 시 clear 작업 진행

### DIFF
--- a/packages/user/src/hooks/query/useGetUserInfo.ts
+++ b/packages/user/src/hooks/query/useGetUserInfo.ts
@@ -14,7 +14,7 @@ export type UserResponse = {
 };
 
 export default function useGetUserInfo() {
-	const { isAuthenticated, token } = useAuth();
+	const { isAuthenticated, token, clearAuthData } = useAuth();
 
 	const {
 		data: userInfo,
@@ -28,6 +28,7 @@ export default function useGetUserInfo() {
 
 	useEffect(() => {
 		if (status === 'error') {
+			clearAuthData();
 			throw new CustomError('유저 정보를 불러오는 중에 문제가 발생하였습니다.', 400);
 		}
 	}, [status]);


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
### as-is
- 유저 정보 불러오는 중에 error 발생 시 error page 띄워줌
_-_ 로그인 정보 만료 시 refresh token 등이 없음 -> 정보를 날려줘야 하는데, 해당 로직 부재
<img width="883" alt="스크린샷 2024-08-19 오전 10 45 21" src="https://github.com/user-attachments/assets/00966e25-0811-48b3-a637-f52bbf460259">

### to-be
- 유저 정보 불러올 때 clear token 로직 추가
- 화면은 띄워줌

  <br/>

## 이미지 첨부

<br/>
