### PR TITLE
[Feature][Task-219] 채팅 리스트 불러오는 로직 구현 & loader, error element 역할 분리

### DIFF
--- a/packages/common/src/components/chat/Message.tsx
+++ b/packages/common/src/components/chat/Message.tsx
@@ -29,7 +29,11 @@ export default function Message({
 				<p className={cn(textColor, 'text-body-3 truncate font-medium')}>익명 {sender} </p>
 				{isMyMessage && <p className={cn(textColor, 'text-body-3 font-medium')}>(나)</p>}
 			</div>
-			<p className={`flex flex-row justify-between flex-1 text-body-3 truncate ${isMyMessage && 'font-medium'}`}>{children}</p>
+			<p
+				className={`text-body-3 flex flex-1 flex-row justify-between truncate ${isMyMessage && 'font-medium'}`}
+			>
+				{children}
+			</p>
 		</div>
 	);
 }

--- a/packages/common/src/constants/socket.ts
+++ b/packages/common/src/constants/socket.ts
@@ -5,6 +5,8 @@ export const CHAT_SOCKET_ENDPOINTS = {
 	PUBLISH: '/app/chat.sendMessage',
 	BLOCK: '/topic/block',
 	NOTICE: '/app/chat.sendNotice',
+	SUBSCRIBE_CHAT_LIST: '/user/queue/chatHistory',
+	PUBLISH_CHAT_LIST: '/app/chat.getHistory',
 } as const;
 
 export const RACING_SOCKET_ENDPOINTS = {

--- a/packages/common/src/utils/socket.ts
+++ b/packages/common/src/utils/socket.ts
@@ -1,7 +1,7 @@
 import { Client, IFrame, IMessage, StompSubscription } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
-export type SocketSubscribeCallbackType = (data: unknown, messageId: string) => void;
+export type SocketSubscribeCallbackType = (data: unknown) => void;
 
 export interface SubscriptionProps {
 	destination: string;
@@ -88,11 +88,7 @@ export default class Socket {
 		const subscriptionProps = {
 			destination,
 			headers,
-			callback: (message: IMessage) => {
-				const messageId = message.headers['message-id'];
-				const data = JSON.parse(message.body);
-				callback(data, messageId);
-			},
+			callback: (message: IMessage) => callback(JSON.parse(message.body)),
 		};
 
 		const subscription = this.client.subscribe(

--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -1,8 +1,8 @@
 import { ChatList } from '@softeer/common/components';
-import ChatInput from 'src/components/event/chatting/inputArea/input/index.tsx';
 import { UseSocketReturnType } from 'src/hooks/socket/index.ts';
 import Chat from './Chat.tsx';
 import ChatInputArea from './inputArea/index.tsx';
+import ChatInput from './inputArea/input/index.tsx';
 
 /** 실시간 기대평 섹션 */
 

--- a/packages/user/src/components/event/racing/index.tsx
+++ b/packages/user/src/components/event/racing/index.tsx
@@ -7,23 +7,26 @@ import RacingRankingDisplay from './controls/index.tsx';
 import RacingDashboard from './dashboard/index.tsx';
 
 /** 실시간 레이싱 섹션 */
-const RealTimeRacing = memo(({ racingSocket }: Pick<UseSocketReturnType, 'racingSocket'>) => {
-	const { ranks, votes, onCarFullyCharged } = racingSocket;
-	const { isCharged, handleCharge } = useChargeHandler(onCarFullyCharged);
+const RealTimeRacing = memo(
+	({
+		racingSocket: { ranks, votes, onCarFullyCharged },
+	}: Pick<UseSocketReturnType, 'racingSocket'>) => {
+		const { isCharged, handleCharge } = useChargeHandler(onCarFullyCharged);
 
-	return (
-		<section
-			id={SECTION_ID.RACING}
-			className="container flex w-[1200px] snap-start flex-col items-center gap-4 pb-[50px] pt-[80px]"
-		>
-			<div className="relative h-[685px] w-full">
-				<RacingDashboard ranks={ranks} isActive={isCharged} />
-				<ChargeButton onCharge={handleCharge} />
-			</div>
-			<RacingRankingDisplay votes={votes} ranks={ranks} isActive={isCharged} />
-		</section>
-	);
-});
+		return (
+			<section
+				id={SECTION_ID.RACING}
+				className="container flex w-[1200px] snap-start flex-col items-center gap-4 pb-[50px] pt-[80px]"
+			>
+				<div className="relative h-[685px] w-full">
+					<RacingDashboard ranks={ranks} isActive={isCharged} />
+					<ChargeButton onCharge={handleCharge} />
+				</div>
+				<RacingRankingDisplay votes={votes} ranks={ranks} isActive={isCharged} />
+			</section>
+		);
+	},
+);
 
 export default RealTimeRacing;
 

--- a/packages/user/src/components/layout/LayoutFallback.tsx
+++ b/packages/user/src/components/layout/LayoutFallback.tsx
@@ -1,0 +1,10 @@
+import DeferredWrapper from 'src/components/common/DeferredWrapper.tsx';
+import PendingContainer from 'src/components/common/PendingContainer.tsx';
+
+export default function LayoutFallback() {
+	return (
+		<DeferredWrapper>
+			<PendingContainer message="사용자 정보를 불러오는 중입니다!" />;
+		</DeferredWrapper>
+	);
+}

--- a/packages/user/src/hooks/query/useGetUserInfo.ts
+++ b/packages/user/src/hooks/query/useGetUserInfo.ts
@@ -5,7 +5,7 @@ import serverTeamEnumToClient from 'src/constants/serverMapping.ts';
 import useAuth from 'src/hooks/useAuth.ts';
 import http from 'src/services/api/index.ts';
 import QUERY_KEYS from 'src/services/api/queryKey.ts';
-import { User } from 'src/types/user.js';
+import type { User } from 'src/types/user.d.ts';
 import CustomError from 'src/utils/error.ts';
 
 export interface UserInfoResponse {

--- a/packages/user/src/hooks/socket/index.ts
+++ b/packages/user/src/hooks/socket/index.ts
@@ -4,26 +4,33 @@ import socketManager from 'src/services/socket.ts';
 import useChatSocket from './useChatSocket.ts';
 import useRacingSocket from './useRacingSocket.ts';
 
+export type UseSocketReturnType = ReturnType<typeof useSocket>;
+
 export default function useSocket() {
 	const { token } = useAuth();
 	const chatSocket = useChatSocket();
 	const racingSocket = useRacingSocket();
 
-	const { onReceiveMessage, onReceiveBlock, ...chatSocketProps } = chatSocket;
+	const { onReceiveMessage, onReceiveChatList, onReceiveBlock, ...chatSocketProps } = chatSocket;
 	const { onReceiveStatus, ...racingSocketProps } = racingSocket;
 
 	const isSocketInitialized = useRef(false);
 
 	useLayoutEffect(() => {
-		if (!isSocketInitialized.current) {
-			socketManager.connectSocketClient({
-				token,
-				onReceiveMessage,
-				onReceiveStatus,
-				onReceiveBlock,
-			});
-			isSocketInitialized.current = true;
-		}
+		const connetSocket = async () => {
+			if (!isSocketInitialized.current) {
+				await socketManager.connectSocketClient({
+					token,
+					onReceiveChatList,
+					onReceiveMessage,
+					onReceiveStatus,
+					onReceiveBlock,
+				});
+				isSocketInitialized.current = true;
+			}
+		};
+
+		connetSocket();
 	}, [token, onReceiveMessage, onReceiveStatus, onReceiveBlock]);
 
 	return { chatSocket: chatSocketProps, racingSocket: racingSocketProps };

--- a/packages/user/src/pages/NotStartedEventPage.tsx
+++ b/packages/user/src/pages/NotStartedEventPage.tsx
@@ -1,23 +1,38 @@
+import { useRouteError } from 'react-router-dom';
 import EventTimer from 'src/components/shared/timer/index.tsx';
 import useGetEventDuration from 'src/hooks/query/useGetEventDuration.ts';
+import ErrorPage from 'src/pages/error/ErrorPage.tsx';
+import CustomError from 'src/utils/error.ts';
 
 export default function NotStartedEventPage() {
+	const error = useRouteError() as CustomError;
+
 	const {
 		duration: { startTime },
 		formattedDuration,
 	} = useGetEventDuration();
 
-	return (
-		<div
-			role="alert"
-			className="gap-15 flex h-screen w-screen flex-col items-center justify-center p-[200px]"
-		>
-			<div className="flex min-w-max flex-col items-center gap-5">
-				<h3>이벤트가 시작하기까지</h3>
-				<EventTimer endTime={startTime} />
-				<p className="text-detail-1 min-w-max font-medium text-neutral-300">{formattedDuration}</p>
+	if (error.status === 403) {
+		return (
+			<div
+				role="alert"
+				className="gap-15 flex h-screen w-screen flex-col items-center justify-center p-[200px]"
+			>
+				<div className="flex min-w-max flex-col items-center gap-5">
+					<h3>이벤트가 시작하기까지</h3>
+					<EventTimer endTime={startTime} />
+					<p className="text-detail-1 min-w-max font-medium text-neutral-300">
+						{formattedDuration}
+					</p>
+				</div>
+				<img
+					src="/images/fcfs/modal.png"
+					alt="오류 발생 이미지"
+					className="w-full max-w-[1000px]"
+				/>
 			</div>
-			<img src="/images/fcfs/modal.png" alt="오류 발생 이미지" className="w-full max-w-[1000px]" />
-		</div>
-	);
+		);
+	}
+
+	return <ErrorPage message={error.message} />;
 }

--- a/packages/user/src/routes/loader/index.ts
+++ b/packages/user/src/routes/loader/index.ts
@@ -1,3 +1,4 @@
 export { default as kakaoRedirectLoader } from './kakao-redirect.ts';
+export { default as layoutLoader } from './layout.ts';
 export { default as rootLoader } from './root.ts';
 export { default as shareRedirectLoader } from './share-redirect.ts';

--- a/packages/user/src/routes/loader/layout.ts
+++ b/packages/user/src/routes/loader/layout.ts
@@ -19,4 +19,6 @@ export default async function layoutLoader() {
 
 		return defer({ userStatus });
 	}
+
+	return null;
 }

--- a/packages/user/src/routes/loader/layout.ts
+++ b/packages/user/src/routes/loader/layout.ts
@@ -1,0 +1,22 @@
+import { ACCESS_TOKEN_KEY } from '@softeer/common/constants';
+import { Cookie } from '@softeer/common/utils';
+import { defer } from 'react-router-dom';
+import { userInfoQueryOptions } from 'src/hooks/query/useGetUserInfo.ts';
+import { queryClient } from 'src/libs/query/index.tsx';
+import QUERY_KEYS from 'src/services/api/queryKey.ts';
+
+export default async function layoutLoader() {
+	const token = Cookie.getCookie<string | null>(ACCESS_TOKEN_KEY);
+
+	if (token) {
+		await queryClient.prefetchQuery(userInfoQueryOptions(token));
+
+		const userStatus = queryClient.getQueryState([QUERY_KEYS.USER_INFO, token]);
+
+		if (userStatus?.status === 'error') {
+			Cookie.clearCookie(ACCESS_TOKEN_KEY);
+		}
+
+		return defer({ userStatus });
+	}
+}

--- a/packages/user/src/routes/loader/root.ts
+++ b/packages/user/src/routes/loader/root.ts
@@ -1,8 +1,5 @@
-import { ACCESS_TOKEN_KEY } from '@softeer/common/constants';
-import { Cookie } from '@softeer/common/utils';
 import { defer } from 'react-router-dom';
 import { EventDuration, eventDurationQueryOptions } from 'src/hooks/query/useGetEventDuration.ts';
-import { userInfoQueryOptions } from 'src/hooks/query/useGetUserInfo.ts';
 import { queryClient } from 'src/libs/query/index.tsx';
 import QUERY_KEYS from 'src/services/api/queryKey.ts';
 import CustomError from 'src/utils/error.ts';
@@ -24,18 +21,6 @@ export default async function rootLoader() {
 
 		if (startTime > currentTime) {
 			throw new CustomError('이벤트가 아직 시작되지 않았습니다.', 403);
-		}
-	}
-
-	const token = Cookie.getCookie<string | null>(ACCESS_TOKEN_KEY);
-
-	if (token) {
-		await queryClient.prefetchQuery(userInfoQueryOptions(token));
-
-		const userStatus = queryClient.getQueryState([QUERY_KEYS.USER_INFO, token]);
-
-		if (userStatus?.status === 'error') {
-			throw new CustomError('사용자 정보를 불러올 수 없습니다.', 404);
 		}
 	}
 

--- a/packages/user/src/routes/router.tsx
+++ b/packages/user/src/routes/router.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { createBrowserRouter, Outlet, RouteObject } from 'react-router-dom';
 import GlobalFallback from 'src/components/layout/GlobalFallback.tsx';
 import Layout from 'src/components/layout/index.tsx';
+import LayoutFallback from 'src/components/layout/LayoutFallback.tsx';
 import RoutePaths from 'src/constants/routePath.ts';
 import AuthProvider from 'src/context/auth/index.tsx';
 import {
@@ -11,7 +12,12 @@ import {
 	NotFoundErrorPage,
 	NotStartedEventPage,
 } from 'src/pages/index.ts';
-import { kakaoRedirectLoader, rootLoader, shareRedirectLoader } from 'src/routes/loader/index.ts';
+import {
+	kakaoRedirectLoader,
+	layoutLoader,
+	rootLoader,
+	shareRedirectLoader,
+} from 'src/routes/loader/index.ts';
 
 const routes: RouteObject[] = [
 	{
@@ -30,10 +36,13 @@ const routes: RouteObject[] = [
 				element: null,
 			},
 			{
+				loader: layoutLoader,
 				element: (
-					<AuthProvider>
-						<Layout />
-					</AuthProvider>
+					<Suspense fallback={<LayoutFallback />}>
+						<AuthProvider>
+							<Layout />
+						</AuthProvider>
+					</Suspense>
 				),
 				errorElement: <ErrorPage />,
 				children: [

--- a/packages/user/src/services/socket.ts
+++ b/packages/user/src/services/socket.ts
@@ -14,6 +14,8 @@ class SocketManager {
 
 	private onReceiveBlock: SocketSubscribeCallbackType | null = null;
 
+	private onReceiveChatList: SocketSubscribeCallbackType | null = null;
+
 	private onReceiveStatus: SocketSubscribeCallbackType | null = null;
 
 	constructor(token: string | null) {
@@ -33,11 +35,13 @@ class SocketManager {
 		onReceiveMessage,
 		onReceiveBlock,
 		onReceiveStatus,
+		onReceiveChatList,
 	}: {
 		token: string | null | undefined;
 		onReceiveMessage: SocketSubscribeCallbackType;
 		onReceiveBlock: SocketSubscribeCallbackType;
 		onReceiveStatus: SocketSubscribeCallbackType;
+		onReceiveChatList: SocketSubscribeCallbackType;
 	}) {
 		if (this.socketClient) {
 			await this.socketClient.disconnect();
@@ -45,6 +49,7 @@ class SocketManager {
 
 		this.initializeSocketClient(token);
 
+		this.onReceiveChatList = onReceiveChatList;
 		this.onReceiveMessage = onReceiveMessage;
 		this.onReceiveBlock = onReceiveBlock;
 		this.onReceiveStatus = onReceiveStatus;
@@ -63,11 +68,19 @@ class SocketManager {
 			onReceiveBlock: this.onReceiveBlock!,
 			onReceiveMessage: this.onReceiveMessage!,
 			onReceiveStatus: this.onReceiveStatus!,
+			onReceiveChatList: this.onReceiveChatList!,
 		});
 	}
 
 	subscribeToTopics() {
 		if (this.socketClient && this.socketClient.client.connected) {
+			if (this.onReceiveChatList) {
+				this.socketClient.subscribe({
+					destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE_CHAT_LIST,
+					callback: this.onReceiveChatList,
+				});
+			}
+
 			if (this.onReceiveMessage) {
 				this.socketClient.subscribe({
 					destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE,


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용

채팅 리스트 불러오는 소켓 기능 구현
- 서버 이슈로 아직 테스트는 해보지 못했습니다. .. 로직 확인은 내일 해봐야 할 것 같네요

다음의 오류 발견해 수정
**as-is**
- 이벤트 기간 정보와 유저 정보를 모두 root loader에서 불러옴
- 해당 loader의 error element는 이벤트 시작 전을 알리는 대기 페이지로 고정되어 있었음
**to-be**
- root loader에서는 이벤트 참여 정보만을, layout loader에서는 유저 정보를 불러오도록 분리 
- root layout에서 오류 생길 경우 이벤트 시작 전일 경우를 제외하고 error page로 라우팅 처리. 



  <br/>

## 이미지 첨부

<br/>
