### PR TITLE
[Perf][Task-159] 접근성 높은 웹페이지 만들기 

### DIFF
--- a/packages/user/src/components/event/chatting/index.tsx
+++ b/packages/user/src/components/event/chatting/index.tsx
@@ -11,7 +11,7 @@ function RealTimeChatting({
 }: Pick<UseSocketReturnType, 'chatSocket'>) {
 	return (
 		<section className="container flex max-w-[1200px] snap-start flex-col items-center pb-[115px] pt-[50px]">
-			<h6 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h6>
+			<h3 className="text-heading-10 mb-[25px] font-medium">기대평을 남겨보세요!</h3>
 			<ChatInputArea>
 				<ChatInput onSend={onSendMessage} />
 			</ChatInputArea>

--- a/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
+++ b/packages/user/src/components/event/racing/controls/ChargeButtonContent.tsx
@@ -14,10 +14,10 @@ const ChargeButtonContent = memo(
 
 		return (
 			<>
-				<h2 className="pt-2">{rank}</h2>
+				<p className="text-heading-2 pt-2 font-extrabold">{rank}</p>
 				<div className="flex flex-col items-center">
-					<p className={`text-body-3 font-medium ${voteStyles[type]}`}>{children}</p>
-					<h6>{displayTitle}</h6>
+					<p className={`text-detail-1 font-medium ${voteStyles[type]}`}>{children}</p>
+					<p className="text-heading-6 font-extrabold">{displayTitle}</p>
 				</div>
 			</>
 		);

--- a/packages/user/src/components/event/racing/dashboard/card/UnassignedCard.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/UnassignedCard.tsx
@@ -9,7 +9,9 @@ export default function UnassignedCard() {
 					alt="캐스퍼 일렉트릭"
 					className="absolute w-[140px] object-contain"
 				/>
-				<h1 className="z-10 mt-[20px] text-[110px] leading-[70px]">?</h1>
+				<p className="text-heading-1 z-10 mt-[20px] text-[110px] font-extrabold leading-[70px]">
+					?
+				</p>
 				<h5 className="z-10 whitespace-pre-line text-center text-[20px] leading-[25px]">
 					당신은
 					<br />

--- a/packages/user/src/components/event/racing/dashboard/card/UnassignedCard.tsx
+++ b/packages/user/src/components/event/racing/dashboard/card/UnassignedCard.tsx
@@ -12,11 +12,11 @@ export default function UnassignedCard() {
 				<p className="text-heading-1 z-10 mt-[20px] text-[110px] font-extrabold leading-[70px]">
 					?
 				</p>
-				<h5 className="z-10 whitespace-pre-line text-center text-[20px] leading-[25px]">
+				<p className="text-body-3 z-10 whitespace-pre-line text-center font-extrabold">
 					당신은
 					<br />
 					<strong>어떤 팀</strong>인가요?
-				</h5>
+				</p>
 				<p className="text-background bg-primary z-10 w-full whitespace-nowrap rounded-[30px] py-[6px] text-center text-[10px] leading-[10px]">
 					자신의 유형 카드를 뽑아보세요!
 				</p>

--- a/packages/user/src/components/home/EventPrizes.tsx
+++ b/packages/user/src/components/home/EventPrizes.tsx
@@ -33,7 +33,7 @@ export default function EventPrizes() {
 	return (
 		<section className="gap-15 flex snap-start flex-col items-center pt-[80px]">
 			<h2>이벤트 경품</h2>
-			<h6 className="text-heading-10">캐스퍼 레이싱</h6>
+			<p className="text-heading-10 font-bold">캐스퍼 레이싱</p>
 			<div className="mb-8 flex gap-3">
 				{EVENT_PRIZES.map(({ drawCount, description }, index) => (
 					<PrizeCard

--- a/packages/user/src/components/home/eventSteps/EventStep.tsx
+++ b/packages/user/src/components/home/eventSteps/EventStep.tsx
@@ -8,10 +8,10 @@ export default function EventStep({ step, title, children }: PropsWithChildren<E
 	const stepLabel = `Step ${step.toString().padStart(2, '0')}`;
 
 	return (
-		<section className="flex flex-col items-center">
-			<h6 className="text-primary text-heading-10 mb-[30px] font-medium">{stepLabel}</h6>
-			<h6 className="text-heading-10 font-medium">{title}</h6>
+		<div className="flex flex-col items-center">
+			<h6 className="text-primary text-heading-8 mb-[30px] font-medium">{stepLabel}</h6>
+			<p className="text-heading-10 font-medium">{title}</p>
 			{children}
-		</section>
+		</div>
 	);
 }

--- a/packages/user/src/components/home/eventSteps/EventStep.tsx
+++ b/packages/user/src/components/home/eventSteps/EventStep.tsx
@@ -9,7 +9,7 @@ export default function EventStep({ step, title, children }: PropsWithChildren<E
 
 	return (
 		<div className="flex flex-col items-center">
-			<h6 className="text-primary text-heading-8 mb-[30px] font-medium">{stepLabel}</h6>
+			<p className="text-primary text-heading-8 mb-[30px] font-medium">{stepLabel}</p>
 			<p className="text-heading-10 font-medium">{title}</p>
 			{children}
 		</div>

--- a/packages/user/src/components/home/quizHint/HintCards.tsx
+++ b/packages/user/src/components/home/quizHint/HintCards.tsx
@@ -71,6 +71,10 @@ function createInfoBox({ title, subTitle, details }: Hint): ReactElement {
 
 function createImage(index: number): ReactElement {
 	return (
-		<img src={`images/hint/${index + 1}.png`} className="h-full w-full object-cover" alt="힌트" />
+		<img
+			src={`images/hint/${index + 1}.png`}
+			className="h-full w-full object-cover"
+			alt="퀴즈 힌트 썸네일 사진"
+		/>
 	);
 }

--- a/packages/user/src/components/home/quizHint/infoTitle.tsx
+++ b/packages/user/src/components/home/quizHint/infoTitle.tsx
@@ -5,7 +5,7 @@ interface InfoTitleProps {
 export default function InfoTitle({ title, subTitle }: InfoTitleProps) {
 	return (
 		<div className="flex flex-col">
-			<h6 className="text-primary text-heading-11 font-medium">{title}</h6>
+			<p className="text-primary text-heading-11 font-medium">{title}</p>
 			<h3 className="text-heading-7 font-bold">{subTitle}</h3>
 		</div>
 	);

--- a/packages/user/src/components/shared/LinkDisplay.tsx
+++ b/packages/user/src/components/shared/LinkDisplay.tsx
@@ -31,19 +31,14 @@ type InputProps = React.InputHTMLAttributes<HTMLInputElement> & VariantProps<typ
 /** 유저 별 이벤트 공유 링크 */
 const LinkDisplay = forwardRef<HTMLInputElement, InputProps>(
 	({ className, variants, ...props }, ref) => (
-		<>
-			<label htmlFor="sharedLink" className="sr-only">
-				유저 별 이벤트 공유 링크
-			</label>
-			<input
-				id="shareLink"
-				type="text"
-				readOnly
-				className={cn(inputVariants({ variants, className }))}
-				ref={ref}
-				{...props}
-			/>
-		</>
+		<input
+			aria-label="유저 별 이벤트 공유 링크"
+			type="text"
+			readOnly
+			className={cn(inputVariants({ variants, className }))}
+			ref={ref}
+			{...props}
+		/>
 	),
 );
 

--- a/packages/user/src/components/shared/LinkDisplay.tsx
+++ b/packages/user/src/components/shared/LinkDisplay.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
 import { cn } from '@softeer/common/utils';
 import { cva, VariantProps } from 'class-variance-authority';
 import clsx from 'clsx';
@@ -30,13 +31,19 @@ type InputProps = React.InputHTMLAttributes<HTMLInputElement> & VariantProps<typ
 /** 유저 별 이벤트 공유 링크 */
 const LinkDisplay = forwardRef<HTMLInputElement, InputProps>(
 	({ className, variants, ...props }, ref) => (
-		<input
-			type="text"
-			readOnly
-			className={cn(inputVariants({ variants, className }))}
-			ref={ref}
-			{...props}
-		/>
+		<>
+			<label htmlFor="sharedLink" className="sr-only">
+				유저 별 이벤트 공유 링크
+			</label>
+			<input
+				id="shareLink"
+				type="text"
+				readOnly
+				className={cn(inputVariants({ variants, className }))}
+				ref={ref}
+				{...props}
+			/>
+		</>
 	),
 );
 

--- a/packages/user/src/components/shared/teamCardTemplate/index.tsx
+++ b/packages/user/src/components/shared/teamCardTemplate/index.tsx
@@ -28,7 +28,7 @@ export default function TeamCardTemplate({
 			<CardGradient variant={type} />
 			<CardContent>
 				<div className="text-center">
-					<h5 className={titleStyles}>{title}</h5>
+					<p className={titleStyles}>{title}</p>
 					<p className={cn(descriptionStyles, 'whitespace-pre-line')}>{subTitle}</p>
 				</div>
 				{children}
@@ -47,17 +47,17 @@ const styles: Record<
 > = {
 	description: {
 		cardStyles: 'h-[364px] w-[244px] pb-[21px] pt-[25px]',
-		titleStyles: '',
+		titleStyles: 'text-heading-5 font-extrabold',
 		descriptionStyles: 'text-detail-2',
 	},
 	racing: {
 		cardStyles: 'w-[160px] h-[234px] pt-[15px] pb-[18px]',
-		titleStyles: 'text-[22px] leading-[22px]',
+		titleStyles: 'text-body-2 font-extrabold leading-[22px]',
 		descriptionStyles: 'text-detail-3 leading-[15px]',
 	},
 	modal: {
 		cardStyles: 'w-[279px] h-[400px] pb-[30px] pt-[25px]',
-		titleStyles: '',
+		titleStyles: 'text-heading-5 font-extrabold',
 		descriptionStyles: 'text-detail-1',
 	},
 };

--- a/packages/user/src/components/shared/timer/TimeUnit.tsx
+++ b/packages/user/src/components/shared/timer/TimeUnit.tsx
@@ -7,10 +7,10 @@ interface TimeUnitProps {
 
 const TimeUnit = memo(({ value, label }: TimeUnitProps) => (
 	<div className="relative flex flex-col items-center gap-4">
-		<div>
-			<h4 className="bg-foreground/10 text-foreground/60 rounded-[5px] p-4 px-3 pt-6 leading-[38px] backdrop-blur-sm">
+		<div className="bg-foreground/10 rounded-[5px] p-4 px-3 pt-6 leading-[38px] backdrop-blur-sm">
+			<span className="text-heading-4 text-foreground/60 text-2xl font-extrabold">
 				{value < 10 ? `0${value}` : value}
-			</h4>
+			</span>
 		</div>
 		<p className="text-detail-2 opacity-60">{label}</p>
 	</div>


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용
> Lighthouse 로 측정된 진단 수치를 기반으로 하여. 접근성 수치 개선을 목표로 진행했습니다.

### as-is
> 웹 접근성은 신경 써서 구현했던 부분이라 초기 진단 시에도 그리 낮은 값은 아니었습니다.

메인 페이지: 94
이벤트 페이지: 98

### to-be
> 거의 대부분 부적절한 h 태그 사용이 이유였습니다. 
> h 태그 사용 기준을 글씨 크기에 맞추고 있었는데, 고칠 수 있는 계기가 되었네요.

메인 페이지: 100
이벤트 페이지: 100

  <br/>

## 이미지 첨부
![스크린샷 2024-08-21 오전 12 58 31](https://github.com/user-attachments/assets/a0bd836c-cf1e-4c01-8763-6133f713e16c)

<br/>
