### PR TITLE
[Perf][Task-156] page component -> lazy loading 적용

### DIFF
--- a/packages/user/src/routes/router.tsx
+++ b/packages/user/src/routes/router.tsx
@@ -1,17 +1,8 @@
-import { Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import { createBrowserRouter, Outlet, RouteObject } from 'react-router-dom';
 import GlobalFallback from 'src/components/layout/GlobalFallback.tsx';
-import Layout from 'src/components/layout/index.tsx';
 import LayoutFallback from 'src/components/layout/LayoutFallback.tsx';
 import RoutePaths from 'src/constants/routePath.ts';
-import AuthProvider from 'src/context/auth/index.tsx';
-import {
-	ErrorPage,
-	EventPage,
-	HomePage,
-	NotFoundErrorPage,
-	NotStartedEventPage,
-} from 'src/pages/index.ts';
 import {
 	kakaoRedirectLoader,
 	layoutLoader,
@@ -19,11 +10,23 @@ import {
 	shareRedirectLoader,
 } from 'src/routes/loader/index.ts';
 
+const AuthProvider = lazy(() => import('src/context/auth/index.tsx'));
+const Layout = lazy(() => import('src/components/layout/index.tsx'));
+const HomePage = lazy(() => import('src/pages/HomePage.tsx'));
+const EventPage = lazy(() => import('src/pages/EventPage.tsx'));
+const ErrorPage = lazy(() => import('src/pages/error/ErrorPage.tsx'));
+const NotFoundErrorPage = lazy(() => import('src/pages/error/NotFoundErrorPage.tsx'));
+const NotStartedEventPage = lazy(() => import('src/pages/NotStartedEventPage.tsx'));
+
 const routes: RouteObject[] = [
 	{
 		path: RoutePaths.Index,
 		loader: rootLoader,
-		errorElement: <NotStartedEventPage />,
+		errorElement: (
+			<Suspense fallback={<GlobalFallback />}>
+				<NotStartedEventPage />
+			</Suspense>
+		),
 		element: (
 			<Suspense fallback={<GlobalFallback />}>
 				<Outlet />
@@ -44,27 +47,50 @@ const routes: RouteObject[] = [
 						</AuthProvider>
 					</Suspense>
 				),
-				errorElement: <ErrorPage />,
+				errorElement: (
+					<Suspense fallback={<GlobalFallback />}>
+						<ErrorPage />
+					</Suspense>
+				),
 				children: [
 					{
 						index: true,
-						element: <HomePage />,
+						element: (
+							<Suspense fallback={<LayoutFallback />}>
+								<HomePage />
+							</Suspense>
+						),
 					},
 					{
 						path: RoutePaths.Event,
-						element: <EventPage />,
+						element: (
+							<Suspense fallback={<LayoutFallback />}>
+								<EventPage />
+							</Suspense>
+						),
 					},
 				],
 			},
 			{
 				loader: kakaoRedirectLoader,
 				path: RoutePaths.KakaoOauthRedirect,
-				errorElement: <ErrorPage />,
+				errorElement: (
+					<Suspense fallback={<GlobalFallback />}>
+						<ErrorPage />
+					</Suspense>
+				),
 				element: null,
 			},
 		],
 	},
-	{ path: '*', element: <NotFoundErrorPage /> },
+	{
+		path: '*',
+		element: (
+			<Suspense fallback={<GlobalFallback />}>
+				<NotFoundErrorPage />
+			</Suspense>
+		),
+	},
 ];
 
 const router = createBrowserRouter(routes);


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용

- page component -> lazy loading 적용
_-_ 500kb 넘는 빌드 파일 분리

  <br/>

## 결과

### before

```bash
vite v5.4.1 building for production...
✓ 338 modules transformed.
dist/index.html                            0.76 kB │ gzip:   0.43 kB
dist/assets/index-8mwCVdNs.css            53.38 kB │ gzip:   9.55 kB
dist/assets/Chip-BB3OGvAg.js               0.37 kB │ gzip:   0.26 kB
dist/assets/PrizeCard-DRfSq3xU.js          0.48 kB │ gzip:   0.35 kB
dist/assets/EventPrizes-B-7jkKot.js        0.87 kB │ gzip:   0.61 kB
dist/assets/index-DoH6GMy4.js              1.61 kB │ gzip:   0.86 kB
dist/assets/EventGuidelines-DQtPzJdo.js    1.67 kB │ gzip:   1.39 kB
dist/assets/index-B1Fc1BaZ.js              1.92 kB │ gzip:   0.93 kB
dist/assets/index-CqEBgYND.js              3.12 kB │ gzip:   1.67 kB
dist/assets/index-CFPKiNl1.js              4.38 kB │ gzip:   2.00 kB
dist/assets/index-CBG3PhQd.js             18.62 kB │ gzip:   7.64 kB
dist/assets/index-0JHCfC1D.js            544.85 kB │ gzip: 179.46 kB

(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
✓ built in 4.37s
```

### after

```bash
vite v5.4.1 building for production...
✓ 337 modules transformed.
dist/index.html                                0.90 kB │ gzip:   0.47 kB
dist/assets/index-8mwCVdNs.css                53.38 kB │ gzip:   9.55 kB
dist/assets/NotFoundErrorPage-B9fTzPQb.js      0.16 kB │ gzip:   0.18 kB
dist/assets/ErrorPage-DfBGaXmy.js              0.23 kB │ gzip:   0.23 kB
dist/assets/scrollToElementId-DDPST3ho.js      0.28 kB │ gzip:   0.23 kB
dist/assets/index-D5bXZqwD.js                  0.34 kB │ gzip:   0.26 kB
dist/assets/Chip-EZCGartQ.js                   0.37 kB │ gzip:   0.26 kB
dist/assets/externalLinks-BosX4DBT.js          0.39 kB │ gzip:   0.23 kB
dist/assets/PrizeCard-DrTERdf0.js              0.48 kB │ gzip:   0.35 kB
dist/assets/index-CjF-JStW.js                  0.50 kB │ gzip:   0.36 kB
dist/assets/InViewLoadSection-qzpTDSgL.js      0.53 kB │ gzip:   0.35 kB
dist/assets/NotStartedEventPage-CH8mI5Lw.js    0.73 kB │ gzip:   0.51 kB
dist/assets/EventPrizes-CN10fDw0.js            0.87 kB │ gzip:   0.61 kB
dist/assets/withAuthHOC-417d9T19.js            1.01 kB │ gzip:   0.67 kB
dist/assets/index-D8FgYB4V.js                  1.14 kB │ gzip:   0.61 kB
dist/assets/index-BFlRvYNl.js                  1.65 kB │ gzip:   0.88 kB
dist/assets/EventGuidelines-BRkDurSq.js        1.67 kB │ gzip:   1.39 kB
dist/assets/index-BvUIL-Dy.js                  2.02 kB │ gzip:   0.98 kB
dist/assets/index-B0Z2nDVe.js                  2.23 kB │ gzip:   1.50 kB
dist/assets/index-Di3DcGAr.js                  2.83 kB │ gzip:   1.43 kB
dist/assets/index-C-rw17J-.js                  3.15 kB │ gzip:   1.68 kB
dist/assets/OptionButton-DQnW_F_a.js           4.02 kB │ gzip:   1.77 kB
dist/assets/index-Bea5THgO.js                  4.46 kB │ gzip:   2.04 kB
dist/assets/index-TtUHMZFP.js                 11.67 kB │ gzip:   4.90 kB
dist/assets/index-CzaXwKGe.js                 18.62 kB │ gzip:   7.64 kB
dist/assets/HomePage-CzPHwDfb.js              19.41 kB │ gzip:   6.59 kB
dist/assets/Modal-DjmhZk68.js                 24.41 kB │ gzip:   8.92 kB
dist/assets/EventPage-D1twj7Mz.js            109.61 kB │ gzip:  37.33 kB
dist/assets/index-DQ5n6lR0.js                369.99 kB │ gzip: 119.66 kB
✓ built in 3.79s
```