### PR TITLE
[Feature] 기대평 채팅 과거 내역 불러오기 & 소켓 관련 에러 탐지용 구독 경로 추가

### DIFF
--- a/packages/common/src/constants/socket.ts
+++ b/packages/common/src/constants/socket.ts
@@ -9,6 +9,8 @@ export const CHAT_SOCKET_ENDPOINTS = {
 	PUBLISH_NOTICE: '/app/chat.sendNotice',
 	SUBSCRIBE_CHAT_LIST: '/user/queue/chatHistory',
 	PUBLISH_CHAT_LIST: '/app/chat.getHistory',
+	SUBSCRIBE_ERROR: '/user/queue/errors',
+
 } as const;
 
 export const RACING_SOCKET_ENDPOINTS = {

--- a/packages/common/src/utils/socket.ts
+++ b/packages/common/src/utils/socket.ts
@@ -13,6 +13,7 @@ export interface SendMessageProps {
 	destination: string;
 	body: unknown;
 	headers?: Record<string, string>;
+	requiresAuth?: boolean;
 }
 
 export default class Socket {
@@ -68,19 +69,17 @@ export default class Socket {
 		}
 	}
 
-	async sendMessages({ destination, body }: SendMessageProps) {
-		if (!this.token) {
+	async sendMessages({ destination, body, headers, requiresAuth = true}: SendMessageProps) {
+		if (requiresAuth && !this.token) {
 			throw new Error('로그인 후 참여할 수 있어요!');
 		}
 
 		const messageProps = {
 			destination,
+			headers,
 			body: JSON.stringify(body),
 		};
 
-		if (!this.client.connected) {
-			await this.connect();
-		}
 		this.client.publish(messageProps);
 	}
 

--- a/packages/user/src/services/socket.ts
+++ b/packages/user/src/services/socket.ts
@@ -72,6 +72,11 @@ class SocketManager {
 
 	async subscribeToTopics() {
 		if (this.socketClient && this.socketClient.client.connected) {
+			this.socketClient.subscribe({
+				destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE_ERROR,
+				callback: (errorMessage) => console.error(errorMessage),
+			});
+
 			if (this.onReceiveChatList) {
 				await this.socketClient.subscribe({
 					destination: CHAT_SOCKET_ENDPOINTS.SUBSCRIBE_CHAT_LIST,


### PR DESCRIPTION
## 🔘Part

- 공통 패키지
- 이벤트 페이지

  <br/>

## 🔎 작업 내용

- 기대평 채팅 과거 내역 불러오기
_-_ 샤라웃 투 @jun-ha 
- 소켓 관련 에러 탐지용 구독 경로 추가
_-_ 예상되는 오류에 대해서는 클라이언트에서 핸들링하고 있습니다. 
_-_ 그 외 오류들에 대해서 처리해주기 위해 error 전용 구독 경로를 개설했습니다.

  <br/>