### PR TITLE
[Fix] 시크릿 탭에서 공유 링크 카운트 업데이트 중복 요청하는 문제

### DIFF
--- a/packages/user/src/routes/loader/share-redirect.ts
+++ b/packages/user/src/routes/loader/share-redirect.ts
@@ -6,7 +6,7 @@ import { queryClient } from 'src/libs/query/index.tsx';
 const shareRedirectLoader: LoaderFunction = async ({ params }) => {
 	const { id } = params;
 
-	await queryClient.prefetchQuery(clickCountQueryOptions(id));
+	await queryClient.fetchQuery(clickCountQueryOptions(id));
 
 	return redirect(RoutePaths.Home);
 };


### PR DESCRIPTION
## 🔘Part

- 이벤트 페이지

  <br/>

## 🔎 작업 내용

- 시크릿 탭에서 공유 링크 카운트 업데이트 중복 요청하는 문제
- 배포 후 확인해봐야 함

  <br/>